### PR TITLE
Consent Flow: First Time Use dialogs

### DIFF
--- a/android/EmptyMatchEngineMavenApp/app/build.gradle
+++ b/android/EmptyMatchEngineMavenApp/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 
-def grpcVersion='1.13.1'
+def grpcVersion = '1.13.1'
 
 android {
     compileSdkVersion 28
@@ -22,20 +22,20 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:design:28.0.0-rc01'
+    implementation 'com.android.support:support-v4:28.0.0-rc01'
 
-    implementation 'com.android.support:support-v4:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
-    // Use maven to get Matching Engine SDK:
-    implementation 'com.mobiledgex:matchingengine:0.0.2'
+    // Matching Engine SDK
+    implementation 'com.mobiledgex:matchingengine:0.0.3'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
 
     // For Google Location Services.
     implementation 'com.google.android.gms:play-services-location:15.0.1'

--- a/android/EmptyMatchEngineMavenApp/app/src/main/AndroidManifest.xml
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- Network Manager -->
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"
@@ -17,19 +17,29 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!-- Entry Activity -->
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Extra launcher for First Time Use UI -->
         <activity
             android:name=".SettingsActivity"
-            android:label="@string/title_activity_settings"></activity>
+            android:label="@string/title_activity_settings" />
+        <activity
+            android:name=".FirstTimeUseActivity"
+            android:configChanges="orientation"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/EnhancedLocationDialog.java
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/EnhancedLocationDialog.java
@@ -17,7 +17,7 @@ public class EnhancedLocationDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         return new AlertDialog.Builder(getActivity())
-                .setMessage(R.string.enchanced_location_permission)
+                .setMessage(R.string.enhanced_location_permission)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {

--- a/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/FirstTimeUseActivity.java
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/FirstTimeUseActivity.java
@@ -1,0 +1,137 @@
+package com.mobiledgex.emptymatchengineapp;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.mobiledgex.matchingengine.util.RequestPermissions;
+
+
+public class FirstTimeUseActivity extends AppCompatActivity {
+
+    private final String TAG = "FirstTimeUseActivity";
+    private RequestPermissions mRpUtil;
+    private AppCompatActivity self;
+    private SharedPreferences prefs;
+    private String prefKeyAllowMEX;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_first_time_use);
+
+        mRpUtil = new RequestPermissions();
+        self = this;
+        prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
+
+        TextView devLocationWhy = findViewById(R.id.permission_location_device_why);
+        devLocationWhy.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                new AlertDialog.Builder(view.getContext())
+                        .setTitle(R.string.location_device_permission_title)
+                        .setMessage(R.string.location_device_permission_explanation)
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                dialogInterface.dismiss();
+                            }
+                        })
+                        .create().show();
+            }
+        });
+
+
+        TextView carrierLocationWhy = findViewById(R.id.permission_location_carrier_why);
+        carrierLocationWhy.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                new AlertDialog.Builder(view.getContext())
+                        .setTitle(R.string.location_carrier_permission_title)
+                        .setMessage(R.string.location_carrier_permission_explanation)
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                dialogInterface.dismiss();
+                            }
+                        })
+                        .create().show();
+            }
+        });
+
+        Button ok = findViewById(R.id.okbutton);
+        ok.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Activity activity = (Activity) view.getContext();
+                if (shouldFinish(activity)) {
+
+                    // Disable first time use.
+                    String firstTimeUseKey = getResources().getString(R.string.preference_first_time_use);
+                    prefs.edit()
+                            .putBoolean(firstTimeUseKey, false)
+                            .apply();
+
+                    activity.finish();
+                } else {
+                    requestPermissions(self);
+                }
+            }
+        });
+
+    }
+
+    private boolean shouldFinish(Activity activity) {
+        final String prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
+        boolean mexLocationAllowed = prefs.getBoolean(prefKeyAllowMEX, false);
+
+        Log.d(TAG, "mexLocationallowed: " + mexLocationAllowed);
+        Log.d(TAG, "Needs More Permissions: " + mRpUtil.getNeededPermissions(self).size());
+        if (mexLocationAllowed &&
+            (mRpUtil.getNeededPermissions(activity).size() == 0)) {
+
+            // Nothing to ask for. Close FirstTimeUseActivity.
+            return true;
+        }
+        return false;
+    }
+
+    private void requestPermissions(AppCompatActivity appCompatActivity) {
+        // As of Android 23, permissions can be asked for while the app is still running.
+        if (mRpUtil.getNeededPermissions(appCompatActivity).size() > 0) {
+            mRpUtil.requestMultiplePermissions(appCompatActivity);
+        }
+        if (!prefs.getBoolean(prefKeyAllowMEX, false)) {
+            new EnhancedLocationDialog().show(appCompatActivity.getSupportFragmentManager(), "dialog");
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if (shouldFinish(this)) {
+            // Nothing to ask for. Close FirstTimeUseActivity.
+            finish();
+        }
+    }
+
+    // From AppCompatActivity interface.
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        // Or replace with an app specific dialog set.
+        mRpUtil.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
+    }
+}

--- a/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -6,7 +6,6 @@ import android.location.Location;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -65,7 +64,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
          * ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION. This creates a dialog, if needed.
          */
         mRpUtil = new RequestPermissions();
-        mRpUtil.requestMultiplePermissions(this);
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
         mLocationRequest = new LocationRequest();
 
@@ -73,6 +71,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
         // Restore mex location preference, defaulting to false:
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        PreferenceManager.setDefaultValues(this, R.xml.location_preferences, false);
+
         boolean mexLocationAllowed = prefs.getBoolean(getResources()
                 .getString(R.string.preference_mex_location_verification),
                 false);
@@ -117,18 +117,17 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         setSupportActionBar(myToolbar);
 
         // Open dialog for MEX if this is the first time the app is created:
-        boolean firstTimeUse = prefs.getBoolean(getResources().getString(R.string.perference_first_time_use), true);
+
+        String firstTimeUsePrefKey = getResources().getString(R.string.preference_first_time_use);
+        boolean firstTimeUse = prefs.getBoolean(firstTimeUsePrefKey, true);
+
         if (firstTimeUse) {
-            new EnhancedLocationDialog().show(this.getSupportFragmentManager(), "dialog");
-            String firstTimeUseKey = getResources().getString(R.string.perference_first_time_use);
-            // Disable first time use.
-            prefs.edit()
-                    .putBoolean(firstTimeUseKey, false)
-                    .apply();
+            Intent intent = new Intent(this, FirstTimeUseActivity.class);
+            startActivity(intent);
         }
 
         // Set, or create create an App generated UUID for use in MatchingEngine, if there isn't one:
-        String uuidKey = getResources().getString(R.string.perference_mex_user_uuid);
+        String uuidKey = getResources().getString(R.string.preference_mex_user_uuid);
         String currentUUID = prefs.getString(uuidKey, "");
         if (currentUUID.isEmpty()) {
             prefs.edit()
@@ -154,7 +153,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
 
-        //noinspection SimplifiableIfStatement
         if (id == R.id.action_settings) {
 
             // Open "Settings" UI
@@ -222,15 +220,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        // Or replace with an app specific dialog set.
-        mRpUtil.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
-    }
-
-
-    @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         final String prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
 
@@ -239,8 +228,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             MatchingEngine.setMexLocationAllowed(mexLocationAllowed);
         }
     }
-
-
 
     public void doEnhancedLocationVerification() throws SecurityException {
         final Activity ctx = this;

--- a/android/EmptyMatchEngineMavenApp/app/src/main/res/layout/activity_first_time_use.xml
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/res/layout/activity_first_time_use.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    tools:context=".FirstTimeUseActivity">
+
+    <ImageView
+        android:id="@+id/permission_icon"
+        android:layout_width="300px"
+        android:layout_height="300px"
+        android:gravity="center"
+        android:src="@android:color/holo_blue_dark"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@+id/permissions_needed_request"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="spread_inside" />
+
+    <TextView
+        android:id="@+id/permissions_needed_request"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/needed_permissions_text"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/imageView"
+        app:layout_constraintTop_toBottomOf="@+id/permission_icon" />
+
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_mylocation"
+        app:layout_constraintBottom_toTopOf="@+id/permission_device_location"
+        app:layout_constraintEnd_toStartOf="@+id/permission_device_location"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/permissions_needed_request" />
+
+    <TextView
+        android:id="@+id/permission_device_location"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+
+        android:text="@string/location_permission_summary"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/permission_location_device_why"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/imageView"
+        app:layout_constraintTop_toBottomOf="@+id/imageView"
+        app:layout_constraintTop_toTopOf="@id/imageView" />
+
+    <TextView
+        android:id="@+id/permission_location_device_why"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:text="@string/why"
+        android:textColor="?attr/colorPrimary"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/imageView2"
+        app:layout_constraintLeft_toLeftOf="@+id/permission_device_location"
+        app:layout_constraintTop_toBottomOf="@+id/permission_device_location" />
+
+    <ImageView
+        android:id="@+id/imageView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_mylocation"
+        app:layout_constraintBottom_toTopOf="@+id/permission_carrier_location"
+        app:layout_constraintEnd_toStartOf="@+id/permission_carrier_location"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/permission_location_device_why" />
+
+    <TextView
+        android:id="@+id/permission_carrier_location"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+
+        android:text="@string/location_carrier_permission_summary"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/permission_location_carrier_why"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/imageView2"
+        app:layout_constraintTop_toBottomOf="@+id/imageView2"
+        app:layout_constraintTop_toTopOf="@id/imageView2"/>
+
+    <TextView
+        android:id="@+id/permission_location_carrier_why"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:text="@string/why"
+        android:textColor="?attr/colorPrimary"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/okbutton"
+        app:layout_constraintLeft_toLeftOf="@+id/permission_carrier_location"
+        app:layout_constraintTop_toBottomOf="@+id/permission_carrier_location" />
+
+    <Button
+        android:id="@+id/okbutton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="OK"
+        app:layout_constraintBottom_toTopOf="@+id/permission_icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/permission_location_carrier_why" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/android/EmptyMatchEngineMavenApp/app/src/main/res/values/strings.xml
+++ b/android/EmptyMatchEngineMavenApp/app/src/main/res/values/strings.xml
@@ -3,11 +3,22 @@
 
     <!-- Strings related to Settings -->
     <string name="action_settings">Settings</string>
-    <string name="perference_first_time_use">first_time_use</string>
-    <string name="perference_mex_user_uuid">mex_user_uuid</string>
-    <string name="enchanced_location_permission">This application uses enhanced features of carrier networks to validate your device location. Please enable in app settings.</string>
+    <string name="preference_first_time_use">first_time_use</string>
+    <string name="preference_mex_user_uuid">mex_user_uuid</string>
+    <string name="enhanced_location_permission">This application uses enhanced features of carrier networks to validate your device location. Please enable in app settings.</string>
     <string name="preference_mex_location_verification">location_verification</string>
     <string name="preference_mex_location_verification_title">Location Verification</string>
     <string name="preference_mex_location_verification_summary">Enhanced Network Location Services</string>
+
+    <string name="needed_permissions_text">We need these permissions to make everything work:</string>
+    <string name="location_permission_summary">Access Device Location Permission Summary</string>
+    <string name="location_carrier_permission_summary">Verify Location with Carrier Location Permission Summary</string>
+    <string name="why">Why?</string>
+
+    <string name="location_device_permission_title">Device Location Verification</string>
+    <string name="location_device_permission_explanation">Location with Device Supplied Location Permission Explanation</string>
+    <string name="location_carrier_permission_title">Carrier Location Verification</string>
+    <string name="location_carrier_permission_explanation">Location with Carrier Supplied Location Permission Explanation</string>
+
     <string name="title_activity_settings">Settings</string>
 </resources>


### PR DESCRIPTION
TDG had a new consent flow. Dialog uses ConstraintLayout, which is nice, although it mainly works well in portrait mode only due to how the dialog is spec'ed out in the original document. It is supposed to "gracefully" re-layout, and does to some extent by layouts by neighbor view edges. May need a scroll-able view later, but the 2 permissions all fit on screen for now.

It is locked in portrait mode for this reason, but you can rotate it in the layout editor if desired.

Art work not already in the standard android theme is not included, as it keeps the size down in the sample, and will be replaced anyway.