### PR TITLE
change port for face detection to avoid collision with k8s proxy

### DIFF
--- a/FaceDetectionServer/Dockerfile
+++ b/FaceDetectionServer/Dockerfile
@@ -3,8 +3,8 @@ COPY requirements.txt /tmp
 WORKDIR /tmp
 RUN pip install -r requirements.txt
 WORKDIR /usr/src/app/moedx
-EXPOSE 8000/tcp
+EXPOSE 8008/tcp
 ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-EXPOSE 8000/tcp
+EXPOSE 8008/tcp
 
-CMD ["gunicorn","moedx.wsgi:application","--preload","--bind","0.0.0.0:8000","--workers=10"]
+CMD ["gunicorn","moedx.wsgi:application","--preload","--bind","0.0.0.0:8008","--workers=10"]

--- a/FaceDetectionServer/client/face_client.py
+++ b/FaceDetectionServer/client/face_client.py
@@ -10,7 +10,7 @@ import time
 
 class RequestClient(object):
     """ """
-    BASE_URL = 'http://%s:8000'
+    BASE_URL = 'http://%s:8008'
     # API_ENDPOINT = '/detect3/'
     API_ENDPOINT = '/detector/detect/'
 

--- a/FaceDetectionServer/client/pyclient.py
+++ b/FaceDetectionServer/client/pyclient.py
@@ -8,7 +8,7 @@ import cv2
 
 class RequestClient(object):
     """ """
-    BASE_URL = 'http://127.0.0.1:8000'
+    BASE_URL = 'http://127.0.0.1:8008'
     API_ENDPOINT = '/detect/'
     
     def __init__(self):

--- a/FaceDetectionServer/moedx/nginx.conf
+++ b/FaceDetectionServer/moedx/nginx.conf
@@ -1,10 +1,10 @@
  server {
-     listen 8000;
+     listen 8008;
      server_name 172.16.1.4;
      access_log  /var/log/nginx/example.log;
 
     location / {
-    	     proxy_pass http://127.0.0.1:8000;
+    	     proxy_pass http://127.0.0.1:8008;
 	     proxy_set_header Host $host;
 	     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
     }

--- a/ios/MobiledgeXSDKDemo/MobiledgeXSDKDemo.IOS/Sample_client.swift
+++ b/ios/MobiledgeXSDKDemo/MobiledgeXSDKDemo.IOS/Sample_client.swift
@@ -1257,7 +1257,7 @@ class MexFaceRecognition
         
         // detector/detect
         // Used to send a face image to the server and get back a set of coordinates for any detected faces.
-        // POST http://<hostname>:8000/detector/detect/
+        // POST http://<hostname>:8008/detector/detect/
         
         let faceDetectionAPI: String = "/detector/detect/"
         
@@ -1269,7 +1269,7 @@ class MexFaceRecognition
         getNetworkLatency(MexUtil.shared.DEF_FACE_HOST_EDGE, post: "updateNetworkLatenciesEdge") // JT 18.12.12
         getNetworkLatency(MexUtil.shared.DEF_FACE_HOST_CLOUD, post: "updateNetworkLatenciesCloud") // JT 18.12.12
         
-        var baseuri = service == "Cloud" ? MexUtil.shared.DEF_FACE_HOST_EDGE : MexUtil.shared.DEF_FACE_HOST_CLOUD + ":" + "8000" // JT 18.12.11
+        var baseuri = service == "Cloud" ? MexUtil.shared.DEF_FACE_HOST_EDGE : MexUtil.shared.DEF_FACE_HOST_CLOUD + ":" + "8008" // JT 18.12.11
         
         var urlStr = "http://" + baseuri + faceDetectionAPI // JT 18.11.27 URLConvertible
         
@@ -1277,7 +1277,7 @@ class MexFaceRecognition
         
         var params: [String: String] = [:] // JT 18.11.27
         
-        //   urlStr = "http://mobiledgexsdkdemomobiledgexsdkdemo10.microsoftwestus2cloudlet.azure.mobiledgex.net:8000/detector/detect/"
+        //   urlStr = "http://mobiledgexsdkdemomobiledgexsdkdemo10.microsoftwestus2cloudlet.azure.mobiledgex.net:8008/detector/detect/"
         
         if let image = image
         {
@@ -1426,7 +1426,7 @@ class MexFaceRecognition
         
         // detector/detect
         // Used to send a face image to the server and get back a set of coordinates for any detected faces.
-        // POST http://<hostname>:8000/detector/detect/
+        // POST http://<hostname>:8008/detector/detect/
         
         let faceRecognitonAPI: String = "/recognizer/predict/"  // JT 18.12.11
         
@@ -1437,7 +1437,7 @@ class MexFaceRecognition
         
         var postMsg =  "faceRecognitionLatency" + service   // JT 18.12.13
         var baseuri = service ==  "Cloud" ? MexUtil.shared.DEF_FACE_HOST_CLOUD : MexUtil.shared.DEF_FACE_HOST_EDGE  // JT 18.12.16
-            + ":" + "8000"
+            + ":" + "8008"
         
         var urlStr = "http://" + baseuri + faceRecognitonAPI // JT 18.11.27 URLConvertible
         
@@ -1445,7 +1445,7 @@ class MexFaceRecognition
         
         var params: [String: String] = [:] // JT 18.11.27
         
-        //   urlStr = "http://mobiledgexsdkdemomobiledgexsdkdemo10.microsoftwestus2cloudlet.azure.mobiledgex.net:8000/recognizer/predict/"
+        //   urlStr = "http://mobiledgexsdkdemomobiledgexsdkdemo10.microsoftwestus2cloudlet.azure.mobiledgex.net:8008/recognizer/predict/"
         
         if let image = image
         {


### PR DESCRIPTION
Port 8000 conflicts with the kube-proxy as provisioned the OpenStack cloudlets.   This change will update the Face detection server to use port 8008 instead of 8000