### PR TITLE
Latency stats dialog

### DIFF
--- a/MobiledgeXSDKDemo/app/build.gradle
+++ b/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 23
         targetSdkVersion 27
-        versionCode 30
+        versionCode 31
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MatchingEngineHelper.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MatchingEngineHelper.java
@@ -198,12 +198,12 @@ public class MatchingEngineHelper {
             AppClient.AppInstListReply cloudletList = mMatchingEngine.getAppInstList(appInstListRequest,
                     host, port, 10000);
             Log.i(TAG, "cloudletList.getStatus()="+cloudletList.getStatus());
-//            if (cloudletList.getStatus() != AppClient.AppInstListReply.AI_Status.AI_SUCCESS) {
-//                someText = "Cannot create AppInstListRequest object. Status="+cloudletList.getStatus()+"\n";
-//                Log.e(TAG, someText);
-//                Snackbar.make(mView, someText, Snackbar.LENGTH_LONG).show();
-//                return null;
-//            }
+            if (cloudletList.getStatus() != AppClient.AppInstListReply.AI_Status.AI_SUCCESS) {
+                someText = "Cannot create AppInstListRequest object. Status="+cloudletList.getStatus()+"\n";
+                Log.e(TAG, someText);
+                Snackbar.make(mView, someText, Snackbar.LENGTH_LONG).show();
+                return false;
+            }
             Log.i(TAG, "REQ_GET_CLOUDLETS cloudletList.getCloudletsCount()=" + cloudletList.getCloudletsCount());
             if (mMatchingEngineResultsListener != null) {
                 mMatchingEngineResultsListener.onGetCloudletList(cloudletList);

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/BoundingBox.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/BoundingBox.java
@@ -63,9 +63,9 @@ public class BoundingBox extends View
 
     public void setCloudletType(Camera2BasicFragment.CloudLetType type) {
         cloudLetType = type;
-        if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUDLET_MEX) {
+        if(cloudLetType == Camera2BasicFragment.CloudLetType.EDGE) {
             textPaint.setTextAlign(Paint.Align.RIGHT);
-        } else if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUDLET_PUBLIC) {
+        } else if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUD) {
             textPaint.setTextAlign(Paint.Align.LEFT);
         }
     }
@@ -81,10 +81,10 @@ public class BoundingBox extends View
         if (subject != null) {
             int x = 0;
             int y = 0;
-            if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUDLET_MEX) {
+            if(cloudLetType == Camera2BasicFragment.CloudLetType.EDGE) {
                 x = rect.right;
                 y = rect.bottom+textSize;
-            } else if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUDLET_PUBLIC) {
+            } else if(cloudLetType == Camera2BasicFragment.CloudLetType.CLOUD) {
                 x = rect.left;
                 y = rect.top-textSize/2;
             }

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/CameraActivity.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/CameraActivity.java
@@ -16,24 +16,40 @@
 
 package com.mobiledgex.sdkdemo.camera;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.WindowManager;
+import android.widget.TextView;
 
+import com.mobiledgex.sdkdemo.MainActivity;
 import com.mobiledgex.sdkdemo.R;
 
 public class CameraActivity extends AppCompatActivity {
 
+    private Camera2BasicFragment cameraFragment;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        System.out.println("BDA9 CameraActivity");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_camera2_basic);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         if (null == savedInstanceState) {
+            cameraFragment = Camera2BasicFragment.newInstance();
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, Camera2BasicFragment.newInstance())
+                    .replace(R.id.container, cameraFragment)
                     .commit();
         }
+    }
+
+    @Override
+    public void finish() {
+        Intent resultIntent = new Intent();
+        String stats = cameraFragment.getStatsText();
+        resultIntent.putExtra("STATS", stats);
+        setResult(RESULT_OK, resultIntent);
+        super.finish();
     }
 }

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/ImageServerInterface.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/ImageServerInterface.java
@@ -6,8 +6,8 @@ import org.json.JSONArray;
  * Interface for clients of the Face/Pose detection/recognition Server.
  */
 public interface ImageServerInterface {
-    void updateFullProcessStats(Camera2BasicFragment.CloudLetType cloudletType, long latency, long stdDev);
-    void updateNetworkStats(Camera2BasicFragment.CloudLetType cloudletType, long latency, long stdDev);
+    void updateFullProcessStats(Camera2BasicFragment.CloudLetType cloudletType, long latency, VolleyRequestHandler.RollingAverage rollingAverage);
+    void updateNetworkStats(Camera2BasicFragment.CloudLetType cloudletType, long latency, VolleyRequestHandler.RollingAverage rollingAverage);
     void updateOverlay(Camera2BasicFragment.CloudLetType cloudletType, JSONArray overlayData);
     void updateOverlay(Camera2BasicFragment.CloudLetType cloudletType, JSONArray overlayData, String subject);
     void updateTrainingProgress(int cloudTrainingCount, int edgeTrainingCount);

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseCameraActivity.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseCameraActivity.java
@@ -1,5 +1,6 @@
 package com.mobiledgex.sdkdemo.camera;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.WindowManager;
@@ -8,16 +9,28 @@ import com.mobiledgex.sdkdemo.R;
 
 public class PoseCameraActivity extends AppCompatActivity {
 
+    private Camera2BasicFragment cameraFragment;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        System.out.println("BDA9 PoseCameraActivity");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_pose_camera);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         if (null == savedInstanceState) {
+            cameraFragment = PoseCameraFragment.newInstance();
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, PoseCameraFragment.newInstance())
+                    .replace(R.id.container, cameraFragment)
                     .commit();
         }
     }
+
+    @Override
+    public void finish() {
+        Intent resultIntent = new Intent();
+        String stats = cameraFragment.getStatsText();
+        resultIntent.putExtra("STATS", stats);
+        setResult(RESULT_OK, resultIntent);
+        super.finish();
+    }
+
 }

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseCameraFragment.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseCameraFragment.java
@@ -13,7 +13,6 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -86,7 +85,8 @@ public class PoseCameraFragment extends Camera2BasicFragment implements ImageSer
         super.showToast(message);
     }
 
-    public void updateFullProcessStats(final Camera2BasicFragment.CloudLetType cloudletType, final long latency, final long stdDev) {
+    public void updateFullProcessStats(final CloudLetType cloudletType, final long latency, VolleyRequestHandler.RollingAverage rollingAverage) {
+        final long stdDev = rollingAverage.getStdDev();
         if(getActivity() == null) {
             Log.w(TAG, "Activity has gone away. Abort UI update");
             return;
@@ -95,8 +95,8 @@ public class PoseCameraFragment extends Camera2BasicFragment implements ImageSer
             @Override
             public void run() {
                 switch(cloudletType) {
-                    case CLOUDLET_MEX:
-                    case CLOUDLET_PUBLIC:
+                    case EDGE:
+                    case CLOUD:
                         mLatencyFull.setText("Full Process Latency: " + String.valueOf(latency/1000000) + " ms");
                         mStdFull.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev/1000000) + " ms");
                         break;
@@ -108,7 +108,8 @@ public class PoseCameraFragment extends Camera2BasicFragment implements ImageSer
     }
 
     @Override
-    public void updateNetworkStats(final Camera2BasicFragment.CloudLetType cloudletType, final long latency, final long stdDev) {
+    public void updateNetworkStats(final CloudLetType cloudletType, final long latency, VolleyRequestHandler.RollingAverage rollingAverage) {
+        final long stdDev = rollingAverage.getStdDev();
         if(getActivity() == null) {
             Log.w(TAG, "Activity has gone away. Abort UI update");
             return;
@@ -117,8 +118,8 @@ public class PoseCameraFragment extends Camera2BasicFragment implements ImageSer
             @Override
             public void run() {
                 switch(cloudletType) {
-                    case CLOUDLET_MEX:
-                    case CLOUDLET_PUBLIC:
+                    case EDGE:
+                    case CLOUD:
                         mLatencyNet.setText("Network Only Latency: " + String.valueOf(latency/1000000) + " ms");
                         mStdNet.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev/1000000) + " ms");
                         break;
@@ -136,8 +137,8 @@ public class PoseCameraFragment extends Camera2BasicFragment implements ImageSer
         prefs.registerOnSharedPreferenceChangeListener(this);
         //We can't create the VolleyRequestHandler until we have a context available.
         mVolleyRequestHandler = new VolleyRequestHandler(this, this.getActivity());
-        mVolleyRequestHandler.edgeImageSender.busy = true; //TODO: Revisit this
-        mVolleyRequestHandler.cloudImageSender.host = "openpose.bonn-mexdemo.mobiledgex.net";
+        mVolleyRequestHandler.cloudImageSender.busy = true; //TODO: Revisit this
+        mVolleyRequestHandler.edgeImageSender.host = "openpose.bonn-mexdemo.mobiledgex.net";
 
         //TODO: Revisit when we have GPU support on multiple servers.
         //The only GPU-enabled server we have doesn't support ping.

--- a/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseRenderer.java
+++ b/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/camera/PoseRenderer.java
@@ -38,6 +38,10 @@ public class PoseRenderer extends View {
             {19,20},{14,21},{11,22},{22,23},{11,24}
     };
 
+    /**
+     * Colors array corresponding to the "pairs" array above. For example, the first pair of
+     * coordinates {1,8} will be drawn with the first color in this array, "#ff0055".
+     */
     private String[] colors = {
             "#ff0055", "#ff0000", "#ff5500", "#ffaa00", "#ffff00", "#aaff00", "#55ff00", "#00ff00",
             "#ff0000", "#00ff55", "#00ffaa", "#00ffff", "#00aaff", "#0055ff", "#0000ff", "#ff00aa",

--- a/MobiledgeXSDKDemo/app/src/main/res/menu/camera_menu.xml
+++ b/MobiledgeXSDKDemo/app/src/main/res/menu/camera_menu.xml
@@ -18,7 +18,4 @@
     <item android:id="@+id/action_camera_training_guest"
         android:checkable="true"
         android:title="Guest Training Mode" />
-    <item android:id="@+id/action_camera_stats_toggle"
-        android:checkable="true"
-        android:title="Collect Stats" />
 </menu>

--- a/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -59,6 +59,10 @@
     <string name="preference_fd_reset_both_hosts">fd_reset_both_hosts</string>
     <string name="preference_fd_reset_both_hosts_title">Reset hosts to default.</string>
     <string name="preference_fd_reset_both_hosts_message">Are you sure?</string>
+    <string name="preference_fd_show_latency_stats_dialog">fd_show_latency_stats_dialog</string>
+    <string name="preference_fd_show_latency_stats_dialog_title">Show Latency Stats after session</string>
+    <string name="preference_fd_show_latency_stats_dialog_summary">Show a dialog with copyable latency stats after ending camera session.</string>
+
     <string name="title_activity_settings">Settings</string>
 
     <string-array name="pref_fd_reset_both_hosts_choices">
@@ -92,7 +96,7 @@
     <string name="action_about">About</string>
     <string name="preference_speed_test_settings">Speed Test Settings</string>
     <string name="preference_general_settings">General Settings</string>
-    <string name="preference_fd_settings">Face Detection Settings</string>
+    <string name="preference_fd_settings">Computer Vision Settings</string>
 
     <string name="camera_error">This device doesn\'t support Camera2 API.</string>
 
@@ -161,7 +165,7 @@
     <string name="face_detection_title">Face Detection</string>
     <string-array name="pref_dme_hostname_titles">
         <item>Demo (mexdemo)</item>
-        <item>DME API Reorg (tdg2)</item>
+        <item>DT LocAPI Integration (tdg2)</item>
         <item>Automation Testing (automationbonn)</item>
     </string-array>
     <string-array name="pref_dme_hostname_values">

--- a/MobiledgeXSDKDemo/app/src/main/res/xml/pref_face_detection.xml
+++ b/MobiledgeXSDKDemo/app/src/main/res/xml/pref_face_detection.xml
@@ -55,5 +55,10 @@
         android:singleLine="false"
         android:summary="@string/preference_fd_host_edge_summary"
         android:title="@string/preference_fd_host_edge_title" />
+    <SwitchPreference
+        android:key="@string/preference_fd_show_latency_stats_dialog"
+        android:title="@string/preference_fd_show_latency_stats_dialog_title"
+        android:summary="@string/preference_fd_show_latency_stats_dialog_summary"
+        android:defaultValue="false" />
 
 </PreferenceScreen>


### PR DESCRIPTION
- Switched to JPEG encoding for uploaded images, for significant latency speedup.
- "Face Detection Settings" renamed to "Computer Vision Settings"
- RollingAverage class has getStatsText method to get a textual summary of the stats.
- Minor refactoring to support each tracked latency value (Edge Full Processing, Edge Network-only, Cloud F.P., Cloud N.O.) has it's own instance of RollingAverage for calculating stats separately. 
- Added communication between MainActivity, CameraActivity, and the fragments to be able to show stats dialog.
- New "Show Latency Stats after session" preference controls whether to show the stats dialog.