### PR TITLE
Add PlatformIntegration.cs/m example to retrive carrierName. Removed extra RegisterClient() call.

### DIFF
--- a/unity/MexRestSample/Assets/MexSample.cs
+++ b/unity/MexRestSample/Assets/MexSample.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 using System;
 using System.IO;
@@ -11,8 +11,8 @@ using DistributedMatchEngine;
 public class MexSample : MonoBehaviour
 {
   public string carrierName { get; set; } = "TDG"; // carrierName depends on the the subscriber SIM card and roaming carriers, and must be supplied a platform API.
+  public string devName { get; set; } = "MobiledgeX";
   public string appName { get; set; } = "MobiledgeX SDK Demo";
-  public string devName { get; set; } = "MobiledgeX SDK Demo";
   public string appVers { get; set; } = "1.0";
   public string developerAuthToken { get; set; } = ""; // This is an opaque string value supplied by the developer.
 
@@ -32,6 +32,7 @@ public class MexSample : MonoBehaviour
   void Start()
   {
     statusContainer = GameObject.Find("/UICanvas/SampleOutput").GetComponent<StatusContainer>();
+
   }
 
   // Update is called once per frame
@@ -41,9 +42,16 @@ public class MexSample : MonoBehaviour
   }
 
   // Get the ephemerial carriername from device specific properties.
-  public async Task<string> getCurrentCarrierName()
+  public string getCurrentCarrierName()
   {
-    var dummy = await Task.FromResult(0);
+    // Call whenever network provider changes, but the demo app pointed to mexdemo server
+    // won't need to track the carrier. The demo requires TDG:
+    var Platform = new PlatformIntegration();
+    string cn = Platform.GetCurrentCarrierName();
+    Debug.Log("Inspection only: Platform carrierName is [" + cn + "]");
+
+
+    // Just return default for MexSample:
     return carrierName;
   }
 
@@ -51,7 +59,7 @@ public class MexSample : MonoBehaviour
   {
     try
     {
-      carrierName = await getCurrentCarrierName();
+      carrierName = getCurrentCarrierName();
 
       Console.WriteLine("RestSample!");
       statusContainer.Post("RestSample!");
@@ -64,7 +72,7 @@ public class MexSample : MonoBehaviour
       var location = await LocationService.RetrieveLocation();
       statusContainer.Post("RestSample Location Task started.");
 
-      var registerClientRequest = dme.CreateRegisterClientRequest(carrierName, appName, devName, appVers, developerAuthToken);
+      var registerClientRequest = dme.CreateRegisterClientRequest(carrierName, devName, appName, appVers, developerAuthToken);
 
       // Await synchronously.
 

--- a/unity/MexRestSample/Assets/PlatformIntegration.cs
+++ b/unity/MexRestSample/Assets/PlatformIntegration.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// We need this one for importing our IOS functions
+using System.Runtime.InteropServices;
+
+public interface CarrierInfo
+{
+  string GetCurrentCarrierName();
+}
+
+public class PlatformIntegration : MonoBehaviour, CarrierInfo
+{
+  [DllImport("__Internal")]
+  private static extern string _getCurrentCarrierName();
+
+  // Start is called before the first frame update
+  void Start()
+  {
+    string networkOperatorName = GetCurrentCarrierName();
+    Debug.Log("networkOperatorName gotten: [" + networkOperatorName + "]");
+  }
+
+  // Update is called once per frame
+  void Update()
+  {
+
+  }
+
+#if UNITY_ANDROID
+  public string GetCurrentCarrierName()
+  {
+    string networkOperatorName = "";
+    AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+    AndroidJavaObject activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+    AndroidJavaObject context = activity.Call<AndroidJavaObject>("getApplicationContext");
+
+    if (context == null)
+    {
+      throw new Exception("Can't find an app context!");
+    }
+
+    // Context.TELEPHONY_SERVICE:
+    string CONTEXT_TELEPHONY_SERVICE = context.GetStatic<String>("TELEPHONY_SERVICE");
+    AndroidJavaObject telManager = context.Call<AndroidJavaObject>("getSystemService", CONTEXT_TELEPHONY_SERVICE);
+
+    if (telManager == null)
+    {
+      Debug.Log("Can't get telephony manager!");
+      return networkOperatorName = "";
+    }
+
+    int simState = telManager.Call<int>("getSimState", new object[0]);
+    Debug.Log("SimState (type Int): [" + simState + "]");
+
+    networkOperatorName = telManager.Call<String>("getNetworkOperatorName", new object[0]);
+
+    if (networkOperatorName == null)
+    {
+      Debug.Log("Network Operator Name is not found on the device");
+      networkOperatorName = "";
+    }
+
+    return networkOperatorName;
+  }
+#elif UNITY_IOS
+  // Create a Objective C file in the Unity generated XCode project, then implement _getCurrentCarrierName() in a class file inside Classes.
+  public string GetCurrentCarrierName()
+  {
+    string networkOperatorName = "";
+    if (Application.platform == RuntimePlatform.IPhonePlayer)
+    {
+      networkOperatorName = _getCurrentCarrierName();
+    }
+    return networkOperatorName;
+  }
+#else
+  public String GetCurrentCarrierName()
+  {
+    Debug.Log("GetCurrentCarrierName is NOT IMPLEMENTED");
+    return "";
+  }
+#endif
+
+}

--- a/unity/MexRestSample/Assets/PlatformIntegration.cs.meta
+++ b/unity/MexRestSample/Assets/PlatformIntegration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f715622b44e054720897e00035a0716c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/MexRestSample/Assets/Scenes/SampleScene.unity
+++ b/unity/MexRestSample/Assets/Scenes/SampleScene.unity
@@ -1516,7 +1516,6 @@ GameObject:
   - component: {fileID: 1511304561}
   - component: {fileID: 1511304563}
   - component: {fileID: 1511304562}
-  - component: {fileID: 1511304564}
   m_Layer: 5
   m_Name: RegisterClient
   m_TagString: Untagged
@@ -1585,19 +1584,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1511304560}
   m_CullTransparentMesh: 0
---- !u!114 &1511304564
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1511304560}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f09a7f8da1abb4523a453ecc89a9fd7d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  registerClientButton: {fileID: 246998966}
 --- !u!1 &1567199472
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/MexRestSample/iosMexRestSample/Classes/PlatformIntegration.m
+++ b/unity/MexRestSample/iosMexRestSample/Classes/PlatformIntegration.m
@@ -1,0 +1,32 @@
+//
+//  PlatformIntegration.m
+//  Unity-iPhone
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <CoreTelephony/CTCarrier.h>
+
+
+char* convertToCStr(const char* str) {
+    if (str == NULL) {
+        return (char*)NULL;
+    }
+
+    size_t len = strlen(str);
+    char* out = (char*)malloc(len + 1);
+    strcpy(out, str);
+    return out;
+}
+
+char* _getCurrentCarrierName()
+{
+    CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
+    CTCarrier *carrier = [netinfo subscriberCellularProvider]; // s for dual SIM?
+    NSLog(@"Carrier Name: %@", [carrier carrierName]);
+    // Ref counted.
+
+    NSString* nsstr = [carrier carrierName];
+
+    return convertToCStr([nsstr UTF8String]);
+}


### PR DESCRIPTION
Copied PlatformIntegration.cs/m code from another sample app being developed. Not strictly necessary in the sample, but works as an example for actual deployments.

Updated devName. Our keys on the server are carrierName: TDG. Things are setup to "work" with mexdemo by default. Currently FindCloudlet does not on UnityEditor, as LocationInfo returns 0,0 as there is no GPS from LocationService.

