### PR TITLE
Add top level license file.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+


### PR DESCRIPTION
EDGECLOUD-568 (edge-cloud-sampleapps repo, not SDK, which is in edge-cloud), Adding a top level license file to start for hackathon. It is Apache v2 + what was indicated in the bug. If that's not the right one, I can change it. 

"git blame" will label every line + contributor of said line diff.

Part 2 is to modify every file, though as a maintenance task, for consistency, every new file should also have this modification.