### PR TITLE
Update sample clients for appcommon.proto change.

### DIFF
--- a/unity/MexRestSample/Assets/FindCloudletButtonScript.cs
+++ b/unity/MexRestSample/Assets/FindCloudletButtonScript.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
@@ -100,7 +100,7 @@ public class FindCloudletButtonScript : MonoBehaviour
                     "Protocol: " + appPort.proto +
                     ", internal_port: " + appPort.internal_port +
                     ", public_port: " + appPort.public_port +
-                    ", public_path: " + appPort.public_path +
+                    ", path_prefix: " + appPort.path_prefix +
                     ", FQDN_prefix: " + appPort.FQDN_prefix
             );
           }

--- a/unity/PongGameExample/PongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PongGameExample/PongGame/Assets/Scripts/GameManager.cs
@@ -230,7 +230,7 @@ namespace MexPongGame {
           foreach (AppPort ap in reply.ports)
           {
             Debug.Log("Port: proto: " + ap.proto + ", prefix: " +
-                ap.FQDN_prefix + ", public path: " + ap.public_path + ", port: " +
+                ap.FQDN_prefix + ", path_prefix: " + ap.path_prefix + ", port: " +
                 ap.public_port);
 
             // We're looking for one of the TCP app ports:


### PR DESCRIPTION
Sync field name change an appcommon.proto.

New Android MatchingEngine SDK version is required for GRPC and REST clients: 1.3.8.