### PR TITLE
EDGECLOUD-828 Fix crashes related to Persistent TCP connection mode

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 42
+        versionCode 43
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/android/MobiledgeXSDKDemo/app/release/output.json
+++ b/android/MobiledgeXSDKDemo/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":41,"versionName":"1.0","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":42,"versionName":"1.0","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "1.4.0"
+project.ext.matchingengineVersion = "1.4.2"
 
 //
 buildscript {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -233,6 +233,10 @@ public class ImageSender {
         // Depending on the connection mode, choose the appropriate way to send the image
         // data to the server.
         if(connectionMode == ConnectionMode.PERSISTENT_TCP) {
+            if(mManager == null) {
+                Log.w(TAG, "ConnectionManager not initialized yet.");
+                return;
+            }
             mManager.send(new TcpImageData(mOpcode, bytes));
 
         } else if(connectionMode == ConnectionMode.REST) {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
@@ -170,8 +170,15 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            getPreferenceScreen().removeAll();
-            addPreferencesFromResource(R.xml.pref_face_detection);
+            // Reinitialize this screen of preferences, since values may have changed.
+            // If an NPE occurs because the PreferenceManager has gone away,
+            // there's no need for any action. Just don't crash the app.
+            try {
+                getPreferenceScreen().removeAll();
+                addPreferencesFromResource(R.xml.pref_face_detection);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
- Fix crash when changing to Persistent TCP connection mode from within any computer vision activity.
- Fix another NPE seen in crash report. Also settings related, but I haven't been able to recreate it. Surrounding code with try/catch should suffice.
- Also update to SDK version 1.4.2.