### PR TITLE
EDGECLOUD-814 Connection to FaceTrainingServer must be REST

### DIFF
--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -237,6 +237,8 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             mProgressText.setText("Collecting images... "+progress+"/"+ImageSender.TRAINING_COUNT_TARGET);
             if(trainingCount >= ImageSender.TRAINING_COUNT_TARGET) {
                 mImageSenderTraining.trainerTrain();
+                mProgressBarTraining.setIndeterminate(true);
+                mProgressText.setText("Updating server...");
             }
 
         } else if(mode == ImageSender.CameraMode.FACE_UPDATING_SERVER) {
@@ -249,6 +251,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             mProgressBarTraining.setVisibility(View.GONE);
             mProgressText.setVisibility(View.GONE);
             guestTrainingMenuUncheck();
+            mCameraMode = ImageSender.CameraMode.FACE_RECOGNITION;
         }
     }
 
@@ -573,8 +576,8 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
         }
         if (key.equals(prefKeyConnectionMode) || key.equals("ALL")) {
             String connectionModeString = sharedPreferences.getString(prefKeyConnectionMode, defaultConnectionMode);
-            Log.i(TAG, "connectionMode=" + connectionModeString+" mImageSenderCloud="+mImageSenderCloud);
-            ImageSender.setConnectionMode(ImageSender.ConnectionMode.valueOf(connectionModeString));
+            Log.i(TAG, "connectionMode=" + connectionModeString+" mImageSenderEdge="+mImageSenderEdge+" mImageSenderCloud="+mImageSenderCloud);
+            ImageSender.setPreferencesConnectionMode(ImageSender.ConnectionMode.valueOf(connectionModeString), mImageSenderEdge, mImageSenderCloud);
         }
         if (key.equals(prefKeyMultiFace) || key.equals("ALL")) {
             prefMultiFace = sharedPreferences.getBoolean(prefKeyMultiFace, true);


### PR DESCRIPTION
A few fixes to Training mode, most of which were needed to coexist with the new Persistent TCP connection mode.
- There is now a separate preferencesConnectionMode static variable and a mConnectionMode instance variable. The static version because we may need to set it before the instances are created, and the instance version because the ImageSender instance for connecting to the FaceTrainingServer must be REST, even if the Cloud and Edge ImageSenders are set to PERSISTENT_TCP.
- Fixed a bug where the PERSISTENT_TCP  ConnectionManager was not initialized correctly when changing the connection mode while the ImageProcessorActivity is currently active.
- Progress bar is set to indeterminate and status set to "Updating Server" at an earlier point for better user feedback.