### PR TITLE
Updating openpose python path

### DIFF
--- a/FaceDetectionServer/README
+++ b/FaceDetectionServer/README
@@ -1,0 +1,9 @@
+To run the server manually:
+
+virtualenv env -ppython3
+source env/bin/activate
+pip install -r requirements.txt
+cd moedx/
+python manage.py makemigrations tracker
+python manage.py migrate
+gunicorn moedx.wsgi:application --bind 0.0.0.0:8008

--- a/FaceDetectionServer/moedx/tracker/apps.py
+++ b/FaceDetectionServer/moedx/tracker/apps.py
@@ -25,7 +25,8 @@ class TrackerConfig(AppConfig):
         global myOpWrapper
         supportOpenPose = False
 
-        sys.path.append('/openpose/build/python')
+        # This assumes openpose has been built from source and installed with "make install".
+        sys.path.append('/usr/local/python')
         try:
             from openpose import pyopenpose as myOpenPose
             supportOpenPose = True


### PR DESCRIPTION
Previous version assumed a symbolic link to the root directory for the openpose build directory. Updated to assume a "make install" has been done, and the library will be available in a common location.

Also added manual startup instructions to the README.
