### PR TITLE
Update default DME hostname

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,7 +9,7 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 47
+        versionCode 48
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -129,7 +129,7 @@ public class MainActivity extends AppCompatActivity
 
     private static final int RC_SIGN_IN = 1;
     public static final int RC_STATS = 2;
-    public static final String DEFAULT_DME_HOSTNAME = "mexdemo.dme.mobiledgex.net";
+    public static final String DEFAULT_DME_HOSTNAME = "sdkdemo.dme.mobiledgex.net";
     public static final String DEFAULT_CARRIER_NAME = "TDG";
     private String mHostname;
     private String mCarrierName;
@@ -1124,7 +1124,7 @@ public class MainActivity extends AppCompatActivity
             String hostAndPort = sharedPreferences.getString(prefKeyDmeHostname, DEFAULT_DME_HOSTNAME+":"+"50051");
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+hostAndPort);
 
-            //Value is in this format: mexdemo.dme.mobiledgex.net:50051
+            //Value is in this format: sdkdemo.dme.mobiledgex.net:50051
             String domainAndPortRegex = "^(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}):\\d+$";
             Pattern domainAndPortPattern = Pattern.compile(domainAndPortRegex);
             Matcher matcher = domainAndPortPattern.matcher(hostAndPort);

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
@@ -569,18 +569,18 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
                 routeNum++;
             }
 
+            LatLngBounds bounds = boundsBuilder.build();
+            int width = getResources().getDisplayMetrics().widthPixels;
+            int height = getResources().getDisplayMetrics().heightPixels;
+            int padding = (int) (height * 0.10); // offset from edges of the map 10% of screen
+            CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, width, height, padding);
+            mMap.animateCamera(cu);
+
         } catch(Exception ex) {
             Log.e(TAG, ex.getLocalizedMessage());
+            toastOnUiThread("Error: "+ex.getLocalizedMessage(), Toast.LENGTH_LONG);
         }
         requestNum++;
-
-        LatLngBounds bounds = boundsBuilder.build();
-        int width = getResources().getDisplayMetrics().widthPixels;
-        int height = getResources().getDisplayMetrics().heightPixels;
-        int padding = (int) (height * 0.10); // offset from edges of the map 10% of screen
-        CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, width, height, padding);
-        mMap.animateCamera(cu);
-
     }
 
     /**

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
         <item>Demo (mexdemo)</item>
     </string-array>
     <string-array name="pref_dme_hostname_values">
-        <item>mexdemo.dme.mobiledgex.net:50051</item>
+        <item>sdkdemo.dme.mobiledgex.net:50051</item>
     </string-array>
     <string name="title_activity_qoe_map">Predictive QoS</string>
     <string name="map_type">Map Type</string>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_general.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_general.xml
@@ -6,7 +6,7 @@
     android:id="@+id/matching_engine_general_preference_screen">
 
     <ListPreference
-        android:defaultValue="mexdemo.dme.mobiledgex.net"
+        android:defaultValue="sdkdemo.dme.mobiledgex.net:50051"
         android:entries="@array/pref_dme_hostname_titles"
         android:entryValues="@array/pref_dme_hostname_values"
         android:key="@string/dme_hostname"


### PR DESCRIPTION
- Fix error that occurred on first time changing DME preference because default value didn't include the port number too.
- Also catch exception when Directions API key isn't valid and display error Toast instead of crashing.