### PR TITLE
Fix PongGame Android PlatformIntegration crash due to threading.

### DIFF
--- a/unity/PongGameExample/PongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PongGameExample/PongGame/Assets/Scripts/GameManager.cs
@@ -77,7 +77,7 @@ namespace MexPongGame {
      * MobiledgeX Integration: thin example encapsulation outside Pong for ease
      * of viewing.
      */
-    MobiledgeXIntegration integration = new MobiledgeXIntegration();
+    MobiledgeXIntegration integration;
 
     string host = "localhost";
     string serverHost = "192.168.1.10"; // Local server hack. Override and set useAltServer=true for dev demo use.
@@ -101,6 +101,7 @@ namespace MexPongGame {
       // Demo mode DME server to run MobiledgeX APIs, or if SIM card is missing
       // and a local DME cannot be located. Set to false if using a supported
       // SIM Card.
+      integration = new MobiledgeXIntegration();
       integration.useDemo = true;
       integration.dmeHost = "sdkdemo." + MatchingEngine.baseDmeHost;
 
@@ -152,6 +153,10 @@ namespace MexPongGame {
         // This app should fallback to public cloud, as the DME doesn't exist for your
         // SIM card + carrier.
         clog("Cannot register to DME host: " + de.Message + ", Stack: " + de.StackTrace);
+        if (de.InnerException != null)
+        {
+          clog("Original Exception: " + de.InnerException.Message);
+        }
         // Handle fallback to public cloud application server.
       }
       catch (HttpRequestException httpre)
@@ -266,7 +271,11 @@ namespace MexPongGame {
       bool registered = false;
       registered = await integration.Register();
 
-      if (registered)
+      if (!registered)
+      {
+        clog("Not Registered!");
+      }
+      else
       {
         FindCloudletReply reply;
         clog("Finding Cloudlet...");

--- a/unity/PongGameExample/PongGame/Assets/Scripts/PlatformIntegration.cs
+++ b/unity/PongGameExample/PongGame/Assets/Scripts/PlatformIntegration.cs
@@ -49,7 +49,7 @@ namespace MexPongGame
        return null;
       }
 
-     AndroidJavaObject context = activity.Call<AndroidJavaObject>("getApplicationContext");
+      AndroidJavaObject context = activity.Call<AndroidJavaObject>("getApplicationContext");
 
       if (context == null)
       {

--- a/unity/PongGameExample/PongGame/ProjectSettings/ProjectVersion.txt
+++ b/unity/PongGameExample/PongGame/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.2.4f1
-m_EditorVersionWithRevision: 2019.2.4f1 (c63b2af89a85)
+m_EditorVersion: 2019.2.6f1
+m_EditorVersionWithRevision: 2019.2.6f1 (fe82a0e88406)


### PR DESCRIPTION
Fixes Android PongGame threading related crash between GameManager async Task Start() and initialization of MobiledgeXIntegration object.