### PR TITLE
Update NetTest to record average and stddev, general fixes.

### DIFF
--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/MobiledgeXIntegration.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/MobiledgeXIntegration.cs
@@ -42,7 +42,7 @@ public class MobiledgeXIntegration
    */
   public string carrierName { get; set; } = "TDG"; // carrierName depends on the available subscriber SIM card and roaming carriers, and must be supplied by platform API.
   public string devName { get; set; } = "MobiledgeX"; // Your developer name.
-  public string appName { get; set; } = "Pong"; // Your appName, if you have created this in the MobiledgeX console.
+  public string appName { get; set; } = "PingPong"; // Your appName, if you have created this in the MobiledgeX console.
   public string appVers { get; set; } = "1.0";
   public string developerAuthToken { get; set; } = ""; // This is an opaque string value supplied by the developer.
 
@@ -84,7 +84,7 @@ public class MobiledgeXIntegration
   }
 
   // These are just thin wrappers over the SDK to show how to use them:
-  // Call once, or when the carrier changes:
+  // Call once, or when the carrier changes. May throw DistributedMatchEngine.HttpException.
   public async Task<bool> Register()
   {
     // If MEX is reachable on your SIM card:
@@ -110,7 +110,7 @@ public class MobiledgeXIntegration
     Debug.Log("AppName: " + req.app_name);
     Debug.Log("AppVers: " + req.app_vers);
 
-    RegisterClientReply reply;
+    RegisterClientReply reply = null;
     if (useDemo)
     {
       reply = await me.RegisterClient(dmeHost, dmePort, req);

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/NetTest.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/NetTest.cs
@@ -15,42 +15,104 @@
  * limitations under the License.
  */
 
-using System.Collections;
 using System.Collections.Concurrent;
 
 using System.Net.Sockets;
+using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 
 using System;
 
 public class NetTest
 {
-  public class HostAndPort
+  public enum TestType
+  {
+    PING = 0,
+    CONNECT = 1,
+  };
+
+  public class Site
   {
     public string host;
     public int port;
-    public double lastPingMs = 0f;
+    public string L7Path; // This may be load balanced.
+    public double lastPingMs;
+
+    public TestType testType;
+
+    int idx;
+    int size;
+    public double[] samples;
+
+    public double average;
+    public double stddev;
+
+    public Site(TestType testType = TestType.CONNECT, int numSamples = 5)
+    {
+      this.testType = testType;
+      samples = new double[numSamples];
+    }
+
+    public void addSample(double time)
+    {
+      samples[idx] = time;
+      idx++;
+      if (size < samples.Length) size++;
+      idx = idx % samples.Length;
+    }
+
+    public void recalculateStats()
+    {
+      double acc = 0d;
+      double vsum = 0d;
+      double d;
+      for (int i = 0; i < size; i++)
+      {
+        acc += samples[i];
+      }
+      average = acc / size;
+      for (int i = 0; i < size; i++)
+      {
+        d = samples[i];
+        vsum += (d - average) * (d - average);
+      }
+      if (size > 1) {
+        // Bias Corrected Sample Variance
+        vsum /= (size - 1);
+      }
+      stddev = Math.Sqrt(vsum);
+    }
   }
   private Stopwatch stopWatch;
 
-  public bool shouldPing = false;
+  public bool runTest;
+
   private Thread pingThread;
   public int PingIntervalMS { get; set; } = 5000;
+  public int TestTimeoutMS = 5000;
 
-  public ConcurrentQueue<HostAndPort> sites;
+  // For testing L7 Sites, possibly load balanced.
+  HttpClient httpClient;
+
+  public ConcurrentQueue<Site> sites { get; }
 
   public NetTest()
   {
     stopWatch = new Stopwatch();
-    sites = new ConcurrentQueue<HostAndPort>();
+    sites = new ConcurrentQueue<Site>();
+
+    // TODO: GetConnection to connect from a particular network interface endpoint
+    httpClient = new HttpClient();
+    httpClient.Timeout = new TimeSpan(0, 0, TestTimeoutMS / 1000); // seconds
   }
 
   // Create a client and connect/disconnect on a server port. Not quite ping ICMP.
-  public double ConnectAndDisconnect(string host, int port=3000)
+  public double ConnectAndDisconnect(string host, int port = 3000)
   {
     stopWatch.Reset();
+
     stopWatch.Start();
     TcpClient client = new TcpClient(host, port);
     client.Close();
@@ -59,35 +121,93 @@ public class NetTest
     return ts.TotalMilliseconds;
   }
 
-  public bool doPing(bool enable)
+  // Create a client and connect/disconnect on a partcular site.
+  public double ConnectAndDisconnect(Site site)
   {
-    shouldPing = enable;
+    stopWatch.Reset();
 
-    if (shouldPing)
+    // The nature of this app specific GET API call is to expect some kind of
+    // stateless empty body return also 200 OK.
+    stopWatch.Start();
+    var result = httpClient.GetAsync(site.L7Path).GetAwaiter().GetResult();
+    TimeSpan ts = stopWatch.Elapsed;
+    stopWatch.Stop();
+
+    if (result.StatusCode == System.Net.HttpStatusCode.OK) {
+      return ts.TotalMilliseconds;
+    }
+
+    // Error, GET on L7 Path didn't return success.
+    return -1d;
+  }
+
+  // Basic ICMP ping.
+  public double Ping(Site site)
+  {
+    Ping ping = new Ping();
+    PingReply reply = ping.Send(site.host, TestTimeoutMS);
+    long elapsedMs = reply.RoundtripTime;
+
+    return elapsedMs;
+  }
+
+  public bool doTest(bool enable)
+  {
+    if (runTest == true && enable == true)
+    {
+      return runTest;
+    }
+
+    runTest = enable;
+    if (runTest)
     {
       pingThread = new Thread(RunNetTest);
       pingThread.Start();
-    } else
+    }
+    else
     {
+      pingThread.Join(PingIntervalMS);
       pingThread = null;
     }
-    return shouldPing;
+    return runTest;
   }
 
   // Basic utility funtion to connect and disconnect from any TCP port.
-  public async void RunNetTest()
+  public void RunNetTest()
   {
-    NetTest nt = new NetTest();
-    while (shouldPing)
+    while (runTest)
     {
-      foreach (HostAndPort site in sites)
+      double elapsed = -1d;
+      foreach (Site site in sites)
       {
-        UnityEngine.Debug.Log("Pinging: " + site.host + ", port: " + site.port);
-        double elapsed = nt.ConnectAndDisconnect(site.host, site.port);
+        switch (site.testType)
+        {
+          case TestType.CONNECT:
+            if (site.L7Path == null) // Simple host and port.
+            {
+              elapsed = ConnectAndDisconnect(site.host, site.port);
+            }
+            else // Use L7 Path.
+            {
+              elapsed = ConnectAndDisconnect(site);
+            }
+            break;
+          case TestType.PING:
+            {
+              elapsed = Ping(site);
+            }
+            break;
+        }
         site.lastPingMs = elapsed;
-        UnityEngine.Debug.Log("Round(-ish) trip to host: " + site.host + ", port: " + site.port + ", elapsed: " + elapsed);
+        if (elapsed >= 0)
+        {
+          site.addSample(elapsed);
+          site.recalculateStats();
+        }
+
+        UnityEngine.Debug.Log("Round trip to host: " + site.host + ", port: " + site.port + ", elapsed: " + elapsed + ", average: " + site.average + ", stddev: " + site.stddev);
       }
-      await Task.Delay(5000);
+      Thread.Sleep(PingIntervalMS);
     }
   }
 }

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/PlatformIntegration.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/PlatformIntegration.cs
@@ -29,15 +29,6 @@ namespace MobiledgeXPingPongGame
 {
   public class PlatformIntegration : DistributedMatchEngine.ICarrierInfo
   {
-    // Sets platform specific internal callbacks (reference counted objects), etc.
-    [DllImport("__Internal")]
-    private static extern string _ensureMatchingEnginePlatformIntegration();
-
-    [DllImport("__Internal")]
-    private static extern string _getCurrentCarrierName();
-
-    [DllImport("__Internal")]
-    private static extern string _getMccMnc();
 
 #if UNITY_ANDROID // PC android target builds to through here as well.
     AndroidJavaObject GetTelephonyManager() {
@@ -121,6 +112,16 @@ namespace MobiledgeXPingPongGame
       return mccmnc;
     }
 #elif UNITY_IOS
+    // Sets iOS platform specific internal callbacks (reference counted objects), etc.
+    [DllImport("__Internal")]
+    private static extern string _ensureMatchingEnginePlatformIntegration();
+
+    [DllImport("__Internal")]
+    private static extern string _getCurrentCarrierName();
+
+    [DllImport("__Internal")]
+    private static extern string _getMccMnc();
+
     public string GetCurrentCarrierName()
     {
       string networkOperatorName = "";

--- a/unity/PingPongGameExample/PingPongGame/ProjectSettings/ProjectSettings.asset
+++ b/unity/PingPongGameExample/PingPongGame/ProjectSettings/ProjectSettings.asset
@@ -164,7 +164,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Android: com.mobiledgex.MexPong
+    Android: com.mobiledgex.PingPong
     Standalone: com.mobiledgex.pongdemogame
     iPhone: com.mobiledgex.ponggame
   buildNumber: {}
@@ -258,7 +258,7 @@ PlayerSettings:
   clonedFromGUID: 5f34be1353de5cf4398729fda238591b
   templatePackageId: com.unity.template.2d@1.3.0
   templateDefaultScene: Assets/Scenes/SampleScene.unity
-  AndroidTargetArchitectures: 5
+  AndroidTargetArchitectures: 3
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -714,7 +714,8 @@ PlayerSettings:
   webGLWasmStreaming: 0
   scriptingDefineSymbols: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Android: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}


### PR DESCRIPTION
- Move IOS only symbols into ifdef. Fixes Android compile error with Unity IL2CPP scripting backend.
- NetTest now calculates average and stddev.
- Improve Exception handling on RegisterClient. Allow "App Not Found" to bubble up to outer handler.