### PR TITLE
Docker OpenPose Integration

### DIFF
--- a/FaceDetectionServer/Dockerfile_openpose
+++ b/FaceDetectionServer/Dockerfile_openpose
@@ -1,0 +1,41 @@
+FROM nvidia/cuda:10.0-cudnn7-devel
+
+#get deps
+RUN apt-get update && \
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+python3-dev python3-pip git g++ wget make libprotobuf-dev protobuf-compiler libopencv-dev \
+libgoogle-glog-dev libboost-all-dev libcaffe-cuda-dev libhdf5-dev libatlas-base-dev
+
+#replace cmake as old version has CUDA variable bugs
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-Linux-x86_64.tar.gz && \
+tar xzf cmake-3.16.0-Linux-x86_64.tar.gz -C /opt && \
+rm cmake-3.16.0-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.16.0-Linux-x86_64/bin:${PATH}"
+
+#get openpose
+WORKDIR /openpose
+RUN git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose.git .
+
+#build it
+WORKDIR /openpose/build
+RUN cmake -DBUILD_PYTHON=ON .. && make -j `nproc`
+WORKDIR /openpose
+
+# Dependencies for our Django app.
+RUN pip3 install wheel
+RUN apt-get install python3-setuptools -y
+COPY requirements.txt /tmp
+WORKDIR /tmp
+RUN pip3 install -r requirements.txt
+WORKDIR /usr/src/app/moedx
+COPY . /usr/src/app
+# Initialize the database.
+RUN python3 manage.py makemigrations tracker
+RUN python3 manage.py migrate
+# port for REST
+EXPOSE 8008/tcp
+# port for persistent TCP server
+EXPOSE 8011/tcp
+ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+CMD ["gunicorn","moedx.wsgi:application","--bind","0.0.0.0:8008","--workers=2"]

--- a/FaceDetectionServer/Makefile
+++ b/FaceDetectionServer/Makefile
@@ -1,11 +1,18 @@
 include Makedefs
 
+# We build differently depending on whether this machine has an Nvidia GPU available.
+GPU := $(shell command -v nvidia-smi 2> /dev/null)
+ifndef GPU
+	DOCKERFILE = Dockerfile
+else
+	DOCKERFILE = Dockerfile_openpose
+endif
+
 default: docker-build docker-push
 
 docker-build:
-	docker build -t mobiledgex/facedetection:${TAG} -f Dockerfile .
+	docker build -t mobiledgex/facedetection:${TAG} -f $(DOCKERFILE) .
 
 docker-push:
 	docker tag mobiledgex/facedetection:${TAG} docker.mobiledgex.net/mobiledgex/images/facedetection:${TAG}
 	docker push docker.mobiledgex.net/mobiledgex/images/facedetection:${TAG}
-


### PR DESCRIPTION
In order to support OpenPose in a Docker container, the "docker build" must take place on a machine with Nvidia drivers/libraries installed (i.e. not a MacBook). This update has the Makefile detect whether the Nvidia stuff is available by trying to execute the nvidia-smi command. If it is successful, a new version of the Dockerfile is used. Otherwise (like on a MacBook), the same old Dockerfile will be used.