### PR TITLE
Add upload speedtest

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,9 +9,12 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 50
-        versionName "1.1.1"
+        versionCode 51
+        versionName "1.1.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]
+        buildConfigField "String", "GOOGLE_DIRECTIONS_API_KEY", "\"${googleDirectionsApiKey}\""
     }
     buildTypes {
         release {

--- a/android/MobiledgeXSDKDemo/app/release/output.json
+++ b/android/MobiledgeXSDKDemo/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":49,"versionName":"1.1.0","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":51,"versionName":"1.1.2","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]

--- a/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
@@ -36,9 +36,8 @@
              sign the APK for publishing.
              You can define the keys for the debug and release targets in src/debug/ and src/release/. 
         -->
-        <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key" />
+        <!--The above is generally true, but for our open source code, we pull the API key from local.properties.-->
+        <meta-data android:name="com.google.android.geo.API_KEY" android:value="${GOOGLE_MAPS_API_KEY}"/>
 
         <activity
             android:name=".MainActivity"

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -44,7 +44,9 @@ import fr.bmartel.speedtest.model.SpeedTestError;
 
 public class Cloudlet implements Serializable {
     private static final String TAG = "Cloudlet";
-    public static final int BYTES_TO_MBYTES = 1024*1024;
+
+    // For data transfer measurements, we use base 10. "Mbits/sec" for displayed units.
+    public static final int BITS_TO_MBITS = 1000*1000;
 
     private String mCloudletName;
     private String mAppName;
@@ -132,7 +134,7 @@ public class Cloudlet implements Serializable {
      */
     private String getDownloadUri() {
         mNumBytes = CloudletListHolder.getSingleton().getNumBytesDownload();
-        return "http://"+hostName+":"+openPort+"/getdata?numbytes="+ mNumBytes;
+        return "http://"+hostName+":"+openPort+"/getdata/?numbytes="+ mNumBytes;
     }
 
     /**
@@ -140,7 +142,7 @@ public class Cloudlet implements Serializable {
      * @return  The URI.
      */
     private String getUploadUri() {
-        return "http://"+hostName+":"+openPort+"/uploaddata";
+        return "http://"+hostName+":"+openPort+"/uploaddata/";
     }
 
     public String toString() {
@@ -418,7 +420,7 @@ public class Cloudlet implements Serializable {
                 public void onCompletion(final SpeedTestReport report) {
                     // called when download is finished
                     Log.v(TAG, "[DOWNLOAD COMPLETED] rate in bit/s   : " + report.getTransferRateBit());
-                    BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
+                    BigDecimal divisor = new BigDecimal(BITS_TO_MBITS);
                     downloadMbps = report.getTransferRateBit().divide(divisor);
                     speedTestDownloadTaskRunning = false;
                     mSpeedTestResultsInterface.onSpeedtestDownloadProgress();
@@ -440,7 +442,7 @@ public class Cloudlet implements Serializable {
                 public void onProgress(final float percent, final SpeedTestReport report) {
                     // called to notify download progress
                     Log.v(TAG, "[DOWNLOAD PROGRESS] "+percent + "% - rate in bit/s   : " + report.getTransferRateBit());
-                    BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
+                    BigDecimal divisor = new BigDecimal(BITS_TO_MBITS);
                     downloadMbps = report.getTransferRateBit().divide(divisor);
                     mSpeedTestDownloadProgress = (int) percent;
                     if(mSpeedTestResultsInterface != null) {
@@ -496,7 +498,7 @@ public class Cloudlet implements Serializable {
                 public void onProgress(final float percent, final SpeedTestReport report) {
                     // called to notify upload progress
                     Log.v(TAG, "[UPLOAD PROGRESS] "+percent + "% - rate in bit/s   : " + report.getTransferRateBit());
-                    BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
+                    BigDecimal divisor = new BigDecimal(BITS_TO_MBITS);
                     uploadMbps = report.getTransferRateBit().divide(divisor);
                     mSpeedTestUploadProgress = (int) percent;
                     if(mSpeedTestResultsInterface != null) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -470,6 +470,7 @@ public class Cloudlet implements Serializable {
                 @Override
                 public void onCompletion(final SpeedTestReport report) {
                     // called when upload is finished
+                    speedTestUploadTaskRunning = false;
                     Log.v(TAG, "[UPLOAD COMPLETED] rate in bit/s   : " + report.getTransferRateBit());
                     // Do not update the transfer rate here because the POST response can take long
                     // enough to receive that it can skew the results, possibly dropping by more than 50 %.

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -42,8 +42,6 @@ import fr.bmartel.speedtest.SpeedTestSocket;
 import fr.bmartel.speedtest.inter.ISpeedTestListener;
 import fr.bmartel.speedtest.model.SpeedTestError;
 
-import static com.mobiledgex.sdkdemo.CloudletListHolder.DownloadTestType.staticFile;
-
 public class Cloudlet implements Serializable {
     private static final String TAG = "Cloudlet";
     public static final int BYTES_TO_MBYTES = 1024*1024;
@@ -62,9 +60,11 @@ public class Cloudlet implements Serializable {
     private double latencyMax=0;
     private double latencyStddev=0;
     private double latencyTotal=0;
-    private BigDecimal mbps = BigDecimal.valueOf(0);
+    private BigDecimal downloadMbps = BigDecimal.valueOf(0);
+    private BigDecimal uploadMbps = BigDecimal.valueOf(0);
     private int latencyTestProgress = 0;
-    private int speedTestProgress = 0;
+    private int mSpeedTestDownloadProgress = 0;
+    private int mSpeedTestUploadProgress = 0;
     private long startTime;
     private double timeDifference;
     private int mNumPackets = 4;
@@ -78,10 +78,13 @@ public class Cloudlet implements Serializable {
     private int openPort = 7777;
     private final int socketTimeout = 3000;
     private boolean latencyTestTaskRunning = false;
-    private boolean speedTestTaskRunning = false;
-    private String uri;
+    private boolean speedTestDownloadTaskRunning = false;
+    private boolean speedTestUploadTaskRunning = false;
+    private String speedTestDownloadErrorMessage = "";
+    private String speedTestUploadErrorMessage = "";
     private String mFqdnPrefix;
     private String mIpAddress;
+    private String uri;
 
     public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String uri, Marker marker, String fqdnPrefix, int port) {
         Log.d(TAG, "Cloudlet contructor. cloudletName="+cloudletName);
@@ -124,36 +127,20 @@ public class Cloudlet implements Serializable {
     }
 
     /**
-     * Build the download URI based on the download type and size preferences.
-     * @return
+     * Build the download URI based on the download size preference.
+     * @return  The URI.
      */
     private String getDownloadUri() {
-        mNumBytes = CloudletListHolder.getSingleton().getNumBytes();
-        String downloadUri;
-        if(CloudletListHolder.getSingleton().getDownloadTestType() == staticFile) {
-            String size;
-            switch(mNumBytes) {
-                case 1024*1024:
-                    size = "1MB";
-                    break;
-                case 5*1024*1024:
-                    size = "5MB";
-                    break;
-                case 10*1024*1024:
-                    size = "10MB";
-                    break;
-                case 20*1024*1024:
-                    size = "20MB";
-                    break;
-                default:
-                    size = "UNKNOWN";
-                    Log.e(TAG, "Unknown download size: "+mNumBytes);
-            }
-            downloadUri = "http://"+hostName+":"+openPort+"/getfile?filename=download_"+size+".txt";
-        } else {
-            downloadUri = "http://"+hostName+":"+openPort+"/getdata?numbytes="+ mNumBytes;
-        }
-        return downloadUri;
+        mNumBytes = CloudletListHolder.getSingleton().getNumBytesDownload();
+        return "http://"+hostName+":"+openPort+"/getdata?numbytes="+ mNumBytes;
+    }
+
+    /**
+     * Build the download URI.
+     * @return  The URI.
+     */
+    private String getUploadUri() {
+        return "http://"+hostName+":"+openPort+"/uploaddata";
     }
 
     public String toString() {
@@ -213,15 +200,22 @@ public class Cloudlet implements Serializable {
         }
     }
 
-    public void startBandwidthTest() {
-        if(speedTestTaskRunning) {
-            Log.d(TAG, "SpeedTest already running");
+    public void startSpeedTestDownload() {
+        Log.d(TAG, "downloadUri=" + getDownloadUri() + " speedTestDownloadTaskRunning="+ speedTestDownloadTaskRunning);
+        if(speedTestDownloadTaskRunning) {
+            Log.d(TAG, "Download SpeedTest already running");
             return;
         }
-        Log.d(TAG, "downloadUri=" + getDownloadUri() + " speedTestTaskRunning="+speedTestTaskRunning);
-        if(!speedTestTaskRunning) {
-            new SpeedTestTask().execute();
+        new SpeedTestDownloadTask().execute();
+    }
+
+    public void startSpeedTestUpload() {
+        Log.d(TAG, "uploadUri=" + getUploadUri() + " speedTestUploadTaskRunning="+ speedTestUploadTaskRunning);
+        if(speedTestUploadTaskRunning) {
+            Log.d(TAG, "Upload SpeedTest already running");
+            return;
         }
+        new SpeedTestUploadTask().execute();
     }
 
     private static boolean isReachable(String addr, int openPort, int timeOutMillis) {
@@ -408,12 +402,13 @@ public class Cloudlet implements Serializable {
 
     }
 
-    public class SpeedTestTask extends AsyncTask<Void, Void, String> {
+    public class SpeedTestDownloadTask extends AsyncTask<Void, Void, String> {
 
         @Override
         protected String doInBackground(Void... params) {
 
-            speedTestTaskRunning = true;
+            speedTestDownloadTaskRunning = true;
+            speedTestDownloadErrorMessage = "";
             SpeedTestSocket speedTestSocket = new SpeedTestSocket();
 
             // add a listener to wait for speedtest completion and progress
@@ -421,34 +416,96 @@ public class Cloudlet implements Serializable {
 
                 @Override
                 public void onCompletion(final SpeedTestReport report) {
-                    // called when download/upload is finished
-                    Log.v(TAG, "[COMPLETED] rate in bit/s   : " + report.getTransferRateBit());
+                    // called when download is finished
+                    Log.v(TAG, "[DOWNLOAD COMPLETED] rate in bit/s   : " + report.getTransferRateBit());
                     BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
-                    mbps = report.getTransferRateBit().divide(divisor);
-                    speedTestProgress = 100;
-                    speedTestTaskRunning = false;
-                    mSpeedTestResultsInterface.onBandwidthProgress();
+                    downloadMbps = report.getTransferRateBit().divide(divisor);
+                    speedTestDownloadTaskRunning = false;
+                    mSpeedTestResultsInterface.onSpeedtestDownloadProgress();
                 }
 
                 @Override
                 public void onError(SpeedTestError speedTestError, String errorMessage) {
-                    // called when a download/upload error occurs
+                    // called when a download error occurs
+                    Log.e(TAG, "Download speedTestError="+speedTestError+" errorMessage="+errorMessage);
+                    speedTestDownloadErrorMessage = speedTestError.toString();
+                    speedTestDownloadTaskRunning = false;
+                    downloadMbps = BigDecimal.valueOf(0);
+                    if(mSpeedTestResultsInterface != null) {
+                        mSpeedTestResultsInterface.onSpeedtestUploadProgress();
+                    }
                 }
 
                 @Override
                 public void onProgress(final float percent, final SpeedTestReport report) {
-                    // called to notify download/upload progress
-                    Log.v(TAG, "[PROGRESS] "+percent + "% - rate in bit/s   : " + report.getTransferRateBit());
+                    // called to notify download progress
+                    Log.v(TAG, "[DOWNLOAD PROGRESS] "+percent + "% - rate in bit/s   : " + report.getTransferRateBit());
                     BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
-                    mbps = report.getTransferRateBit().divide(divisor);
-                    speedTestProgress = (int) percent;
+                    downloadMbps = report.getTransferRateBit().divide(divisor);
+                    mSpeedTestDownloadProgress = (int) percent;
                     if(mSpeedTestResultsInterface != null) {
-                        mSpeedTestResultsInterface.onBandwidthProgress();
+                        mSpeedTestResultsInterface.onSpeedtestDownloadProgress();
                     }
                 }
             });
 
             speedTestSocket.startDownload(getDownloadUri());
+
+            return null;
+        }
+    }
+
+    public class SpeedTestUploadTask extends AsyncTask<Void, Void, String> {
+
+        @Override
+        protected String doInBackground(Void... params) {
+
+            speedTestUploadTaskRunning = true;
+            speedTestUploadErrorMessage = "";
+            SpeedTestSocket speedTestSocket = new SpeedTestSocket();
+
+            // add a listener to wait for speedtest completion and progress
+            speedTestSocket.addSpeedTestListener(new ISpeedTestListener() {
+
+                @Override
+                public void onCompletion(final SpeedTestReport report) {
+                    // called when upload is finished
+                    Log.v(TAG, "[UPLOAD COMPLETED] rate in bit/s   : " + report.getTransferRateBit());
+                    // Do not update the transfer rate here because the POST response can take long
+                    // enough to receive that it can skew the results, possibly dropping by more than 50 %.
+                }
+
+                @Override
+                public void onError(SpeedTestError speedTestError, String errorMessage) {
+                    // called when a upload error occurs
+                    Log.e(TAG, "Upload speedTestError="+speedTestError+" errorMessage="+errorMessage);
+                    // A second error may occur as SOCKET_TIMEOUT, which would overwrite a more useful
+                    // INVALID_HTTP_RESPONSE error, so only keep the first error per run.
+                    if (speedTestUploadErrorMessage.isEmpty()) {
+                        speedTestUploadErrorMessage = speedTestError.toString();
+                    }
+                    speedTestUploadTaskRunning = false;
+                    uploadMbps = BigDecimal.valueOf(0);
+                    if(mSpeedTestResultsInterface != null) {
+                        mSpeedTestResultsInterface.onSpeedtestUploadProgress();
+                    }
+                }
+
+                @Override
+                public void onProgress(final float percent, final SpeedTestReport report) {
+                    // called to notify upload progress
+                    Log.v(TAG, "[UPLOAD PROGRESS] "+percent + "% - rate in bit/s   : " + report.getTransferRateBit());
+                    BigDecimal divisor = new BigDecimal(BYTES_TO_MBYTES);
+                    uploadMbps = report.getTransferRateBit().divide(divisor);
+                    mSpeedTestUploadProgress = (int) percent;
+                    if(mSpeedTestResultsInterface != null) {
+                        mSpeedTestResultsInterface.onSpeedtestUploadProgress();
+                    }
+                }
+            });
+
+            mNumBytes = CloudletListHolder.getSingleton().getNumBytesUpload();
+            speedTestSocket.startUpload(getUploadUri(), mNumBytes);
 
             return null;
         }
@@ -537,16 +594,32 @@ public class Cloudlet implements Serializable {
         return latencyStddev;
     }
 
-    public BigDecimal getMbps() {
-        return mbps;
+    public String getSpeedTestDownloadResult() {
+        if (speedTestDownloadErrorMessage.isEmpty()) {
+            return String.format("%.2f", downloadMbps) + " Mbits/sec";
+        } else {
+            return speedTestDownloadErrorMessage;
+        }
+    }
+
+    public String getSpeedTestUploadResult() {
+        if (speedTestUploadErrorMessage.isEmpty()) {
+            return String.format("%.2f", uploadMbps) + " Mbits/sec";
+        } else {
+            return speedTestUploadErrorMessage;
+        }
     }
 
     public int getLatencyTestProgress() {
         return latencyTestProgress;
     }
 
-    public int getSpeedTestProgress() {
-        return speedTestProgress;
+    public int getSpeedTestDownloadProgress() {
+        return mSpeedTestDownloadProgress;
+    }
+
+    public int getSpeedTestUploadProgress() {
+        return mSpeedTestUploadProgress;
     }
 
     public boolean isPingFailed() {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -39,7 +39,8 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
     private Cloudlet cloudlet;
     private TextView cloudletNameTv;
     private TextView appNameTv;
-    private TextView speedtestResultsTv;
+    private TextView speedtestDownloadResultsTv;
+    private TextView speedtestUploadResultsTv;
     private TextView latencyMinTv;
     private TextView latencyAvgTv;
     private TextView latencyMaxTv;
@@ -50,9 +51,11 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
     private TextView distanceTv;
     private TextView latitudeTv;
     private TextView longitudeTv;
-    private Button buttonSpeedTest;
+    private Button buttonSpeedTestDownload;
+    private Button buttonSpeedTestUpload;
     private Button buttonLatencyTest;
     private ProgressBar progressBarDownload;
+    private ProgressBar progressBarUpload;
     private ProgressBar progressBarLatency;
 
     @Override
@@ -80,13 +83,15 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
         distanceTv = findViewById(R.id.distance);
         latitudeTv = findViewById(R.id.latitude);
         longitudeTv = findViewById(R.id.longitude);
-        speedtestResultsTv = findViewById(R.id.speedtestResults);
+        speedtestDownloadResultsTv = findViewById(R.id.speedtestDownloadResults);
+        speedtestUploadResultsTv = findViewById(R.id.speedtestUploadResults);
         latencyMinTv = findViewById(R.id.latencyMin);
         latencyAvgTv = findViewById(R.id.latencyAvg);
         latencyMaxTv = findViewById(R.id.latencyMax);
         latencyStddevTv = findViewById(R.id.latencyStddev);
         latencyMessageTv = findViewById(R.id.latencyMessage);
         progressBarDownload = findViewById(R.id.progressBarDownload);
+        progressBarUpload = findViewById(R.id.progressBarUpload);
         progressBarLatency = findViewById(R.id.progressBarLatency);
 
         cloudletNameTv.setText(cloudlet.getCloudletName());
@@ -96,11 +101,18 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
         latitudeTv.setText(Double.toString(cloudlet.getLatitude()));
         longitudeTv.setText(Double.toString(cloudlet.getLongitude()));
 
-        buttonSpeedTest = findViewById(R.id.buttonSpeedtest);
-        buttonSpeedTest.setOnClickListener(new View.OnClickListener() {
+        buttonSpeedTestDownload = findViewById(R.id.buttonSpeedtestDownload);
+        buttonSpeedTestDownload.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                cloudlet.startBandwidthTest();
+                cloudlet.startSpeedTestDownload();
+            }
+        });
+        buttonSpeedTestUpload = findViewById(R.id.buttonSpeedtestUpload);
+        buttonSpeedTestUpload.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                cloudlet.startSpeedTestUpload();
             }
         });
         buttonLatencyTest = findViewById(R.id.buttonLatencytest);
@@ -175,7 +187,12 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
     }
 
     @Override
-    public void onBandwidthProgress() {
+    public void onSpeedtestDownloadProgress() {
+        updateUi();
+    }
+
+    @Override
+    public void onSpeedtestUploadProgress() {
         updateUi();
     }
 
@@ -189,6 +206,7 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
             @Override
             public void run() {
                 CloudletListHolder.LatencyTestMethod latencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
+                latencyMessageTv.setText("Method: "+latencyTestMethod.name());
                 if(cloudlet.getCarrierName().equalsIgnoreCase("azure")) {
                     if(latencyTestMethod == CloudletListHolder.LatencyTestMethod.ping) {
                         latencyMessageTv.setText("Socket test forced");
@@ -211,8 +229,10 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
                 latencyMaxTv.setText(formatValue(cloudlet.getLatencyMax())+" ms");
                 latencyStddevTv.setText(formatValue(cloudlet.getLatencyStddev())+" ms");
                 progressBarLatency.setProgress(cloudlet.getLatencyTestProgress());
-                progressBarDownload.setProgress(cloudlet.getSpeedTestProgress());
-                speedtestResultsTv.setText(String.format("%.2f", cloudlet.getMbps())+" Mbits/sec");
+                progressBarDownload.setProgress(cloudlet.getSpeedTestDownloadProgress());
+                progressBarUpload.setProgress(cloudlet.getSpeedTestUploadProgress());
+                speedtestDownloadResultsTv.setText(cloudlet.getSpeedTestDownloadResult());
+                speedtestUploadResultsTv.setText(cloudlet.getSpeedTestUploadResult());
                 distanceTv.setText(String.format("%.4f", cloudlet.getDistance()));
                 ipAddressTv.setText(cloudlet.getIpAddress());
             }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -33,7 +33,6 @@ import android.widget.TextView;
 
 public class CloudletDetailsActivity extends AppCompatActivity implements SpeedTestResultsInterface {
 
-    public static final int BYTES_TO_MBYTES = 1024*1024;
     private static final String TAG = "CloudletDetailsActivity";
     private Intent intent;
     private Cloudlet cloudlet;

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletListHolder.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletListHolder.java
@@ -27,21 +27,29 @@ public class CloudletListHolder {
 
     private ArrayMap<String, Cloudlet> mCloudletList = new ArrayMap<>();
     private LatencyTestMethod latencyTestMethod = LatencyTestMethod.ping;
-    private DownloadTestType downloadTestType = DownloadTestType.dynamic;
     private boolean latencyTestAutoStart;
-    private int numBytes;
+    private int numBytesDownload;
+    private int numBytesUpload;
     private int numPackets;
 
     public static CloudletListHolder getSingleton() {
         return ourInstance;
     }
 
-    public int getNumBytes() {
-        return numBytes;
+    public int getNumBytesDownload() {
+        return numBytesDownload;
     }
 
-    public void setNumBytes(int numBytes) {
-        this.numBytes = numBytes;
+    public void setNumBytesDownload(int numBytes) {
+        this.numBytesDownload = numBytes;
+    }
+
+    public int getNumBytesUpload() {
+        return numBytesUpload;
+    }
+
+    public void setNumBytesUpload(int numBytes) {
+        this.numBytesUpload = numBytes;
     }
 
     public int getNumPackets() {
@@ -57,11 +65,6 @@ public class CloudletListHolder {
         socket
     }
 
-    public enum DownloadTestType {
-        dynamic,
-        staticFile
-    }
-
     private CloudletListHolder() {
     }
 
@@ -71,15 +74,6 @@ public class CloudletListHolder {
 
     public void setCloudlets(ArrayMap<String, Cloudlet> mCloudlets) {
         this.mCloudletList = mCloudlets;
-    }
-
-    public DownloadTestType getDownloadTestType() {
-        return downloadTestType;
-    }
-
-    public void setDownloadTestType(String downloadTestType) {
-        this.downloadTestType = DownloadTestType.valueOf(downloadTestType);
-        System.out.println("String DownloadTestType="+downloadTestType+" enum downloadTestType="+this.downloadTestType);
     }
 
     public boolean getLatencyTestAutoStart() {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -264,8 +264,8 @@ public class MainActivity extends AppCompatActivity
         // Reuse the onSharedPreferenceChanged code to initialize anything dependent on these prefs:
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.dme_hostname));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_operator_name));
-        onSharedPreferenceChanged(prefs, getResources().getString(R.string.download_type));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.download_size));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.upload_size));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.latency_packets));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.latency_method));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_latency_autostart));
@@ -1009,7 +1009,7 @@ public class MainActivity extends AppCompatActivity
 
         String cloudletName = (String) marker.getTag();
         Cloudlet cloudlet = CloudletListHolder.getSingleton().getCloudletList().get(cloudletName);
-        Log.i(TAG, "1."+cloudlet+" "+cloudlet.getCloudletName()+" "+cloudlet.getMbps());
+        Log.i(TAG, "1."+cloudlet+" "+cloudlet.getCloudletName()+" "+cloudlet.getSpeedTestDownloadResult());
 
         Intent intent = new Intent(getApplicationContext(), CloudletDetailsActivity.class);
         intent.putExtra("CloudletName", cloudlet.getCloudletName());
@@ -1098,8 +1098,8 @@ public class MainActivity extends AppCompatActivity
         Log.d(TAG, "onSharedPreferenceChanged("+key+")");
         String prefKeyAllowMatchingEngineLocation = getResources().getString(R.string.preference_matching_engine_location_verification);
         String prefKeyAllowNetSwitch = getResources().getString(R.string.preference_net_switching_allowed);
-        String prefKeyDownloadType = getResources().getString(R.string.download_type);
         String prefKeyDownloadSize = getResources().getString(R.string.download_size);
+        String prefKeyUploadSize = getResources().getString(R.string.upload_size);
         String prefKeyNumPackets = getResources().getString(R.string.latency_packets);
         String prefKeyLatencyMethod = getResources().getString(R.string.latency_method);
         String prefKeyLatencyAutoStart = getResources().getString(R.string.pref_latency_autostart);
@@ -1174,16 +1174,16 @@ public class MainActivity extends AppCompatActivity
             }
         }
 
-        if (key.equals(prefKeyDownloadType)) {
-            String downloadType = sharedPreferences.getString(prefKeyDownloadType, "dynamic");
-            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+downloadType);
-            CloudletListHolder.getSingleton().setDownloadTestType(downloadType);
-        }
-
         if (key.equals(prefKeyDownloadSize)) {
             int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyDownloadSize, "1048576"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
-            CloudletListHolder.getSingleton().setNumBytes(numBytes);
+            CloudletListHolder.getSingleton().setNumBytesDownload(numBytes);
+        }
+
+        if (key.equals(prefKeyUploadSize)) {
+            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyUploadSize, "1048576"));
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
+            CloudletListHolder.getSingleton().setNumBytesUpload(numBytes);
         }
 
         if (key.equals(prefKeyNumPackets)) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -1175,13 +1175,13 @@ public class MainActivity extends AppCompatActivity
         }
 
         if (key.equals(prefKeyDownloadSize)) {
-            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyDownloadSize, "1048576"));
+            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyDownloadSize, "10485760"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
             CloudletListHolder.getSingleton().setNumBytesDownload(numBytes);
         }
 
         if (key.equals(prefKeyUploadSize)) {
-            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyUploadSize, "1048576"));
+            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyUploadSize, "5242880"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
             CloudletListHolder.getSingleton().setNumBytesUpload(numBytes);
         }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SpeedTestResultsInterface.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SpeedTestResultsInterface.java
@@ -19,6 +19,7 @@ package com.mobiledgex.sdkdemo;
 
 public interface SpeedTestResultsInterface {
     void onLatencyProgress();
-    void onBandwidthProgress();
+    void onSpeedtestDownloadProgress();
+    void onSpeedtestUploadProgress();
     void onIpAddressResolved();
 }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
@@ -578,7 +578,7 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
             mMap.animateCamera(cu);
 
         } catch(Exception ex) {
-            Log.e(TAG, ex.getCause()+" "+ex.getLocalizedMessage());
+            Log.e(TAG, "Error during routeBetweenPoints: "+ex.getLocalizedMessage());
             toastOnUiThread("Error: "+ex.getLocalizedMessage(), Toast.LENGTH_LONG);
         }
         requestNum++;

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
@@ -70,6 +70,7 @@ import com.google.maps.model.EncodedPolyline;
 import com.google.maps.model.TravelMode;
 import com.mobiledgex.matchingengine.ChannelIterator;
 import com.mobiledgex.matchingengine.MatchingEngine;
+import com.mobiledgex.sdkdemo.BuildConfig;
 import com.mobiledgex.sdkdemo.MainActivity;
 import com.mobiledgex.sdkdemo.MatchingEngineHelper;
 import com.mobiledgex.sdkdemo.R;
@@ -209,7 +210,7 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        apiKey = getResources().getString(R.string.google_directions_api_key);
+        apiKey = BuildConfig.GOOGLE_DIRECTIONS_API_KEY;
 
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
@@ -577,7 +578,7 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
             mMap.animateCamera(cu);
 
         } catch(Exception ex) {
-            Log.e(TAG, ex.getLocalizedMessage());
+            Log.e(TAG, ex.getCause()+" "+ex.getLocalizedMessage());
             toastOnUiThread("Error: "+ex.getLocalizedMessage(), Toast.LENGTH_LONG);
         }
         requestNum++;

--- a/android/MobiledgeXSDKDemo/app/src/main/res/layout/activity_cloudlet_details.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/layout/activity_cloudlet_details.xml
@@ -259,17 +259,40 @@
                     android:padding="5dip">
 
                     <Button
-                        android:id="@+id/buttonSpeedtest"
-                        android:text="Speed Test" />
+                        android:id="@+id/buttonSpeedtestDownload"
+                        android:text="@string/download_speed_test" />
 
                     <TextView
-                        android:id="@+id/speedtestResults"
+                        android:id="@+id/speedtestDownloadResults"
                         android:text=""
                         android:textAppearance="?android:attr/textAppearanceMedium" />
                 </TableRow>
 
                 <ProgressBar
                     android:id="@+id/progressBarDownload"
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:max="100" />
+
+                <TableRow
+                    android:id="@+id/tableRow12"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="5dip">
+
+                    <Button
+                        android:id="@+id/buttonSpeedtestUpload"
+                        android:text="@string/upload_speed_test" />
+
+                    <TextView
+                        android:id="@+id/speedtestUploadResults"
+                        android:text=""
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                </TableRow>
+
+                <ProgressBar
+                    android:id="@+id/progressBarUpload"
                     style="?android:attr/progressBarStyleHorizontal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -53,26 +53,34 @@
     <string name="download_size">download_size</string>
     <string-array name="pref_download_size_titles">
         <item>1 MB</item>
-        <item>5 MB</item>
         <item>10 MB</item>
-        <item>20 MB</item>
+        <item>50 MB</item>
+        <item>100 MB</item>
+        <item>250 MB</item>
     </string-array>
     <string-array name="pref_download_size_values">
         <item>1048576</item>
-        <item>5242880</item>
         <item>10485760</item>
-        <item>20971520</item>
+        <item>52428800</item>
+        <item>104857600</item>
+        <item>262144000</item>
     </string-array>
 
-    <string name="pref_title_download_type">Download Type</string>
-    <string name="download_type">download_type</string>
-    <string-array name="pref_download_type_titles">
-        <item>Dynamically Generated</item>
-        <item>Static Files</item>
+    <string name="pref_title_upload_size">Upload Size</string>
+    <string name="upload_size">upload_size</string>
+    <string-array name="pref_upload_size_titles">
+        <item>1 MB</item>
+        <item>5 MB</item>
+        <item>25 MB</item>
+        <item>50 MB</item>
+        <item>100 MB</item>
     </string-array>
-    <string-array name="pref_download_type_values">
-        <item>dynamic</item>
-        <item>staticFile</item>
+    <string-array name="pref_upload_size_values">
+        <item>1048576</item>
+        <item>5242880</item>
+        <item>26214400</item>
+        <item>52428800</item>
+        <item>104857600</item>
     </string-array>
 
     <string name="pref_title_latency_packets">Latency Test Packets</string>
@@ -111,7 +119,7 @@
     <string name="dme_hostname">dme_hostname</string>
     <string name="pref_summary_latency_method">Select socket connection or ICMP ping</string>
     <string name="pref_summary_latency_packets">Number of times to repeat latency test</string>
-    <string name="pref_summary_download_type">Type of data to use for download for speed test</string>
+    <string name="pref_summary_upload_size">Number of Megabytes to upload for speed test</string>
     <string name="pref_summary_download_size">Number of Megabytes to download for speed test</string>
     <string-array name="pref_dme_hostname_titles">
         <item>Demo (mexdemo)</item>
@@ -132,5 +140,7 @@
     <string name="pqoe_map_type_terrain">Terrain</string>
     <string name="pqoe_map_type_hybrid">Hybrid</string>
     <string name="pqoe_map_type_silver">Silver</string>
+    <string name="upload_speed_test">UL Speed Test</string>
+    <string name="download_speed_test">DL Speed Test</string>
 
 </resources>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
@@ -4,17 +4,7 @@
          dismiss it. -->
     <!-- NOTE: ListPreference's summary should be set to its value by the activity code. -->
     <ListPreference
-        android:defaultValue="dynamic"
-        android:entries="@array/pref_download_type_titles"
-        android:entryValues="@array/pref_download_type_values"
-        android:key="@string/download_type"
-        android:negativeButtonText="@null"
-        android:positiveButtonText="@null"
-        android:summary="@string/pref_summary_download_type"
-        android:title="@string/pref_title_download_type" />
-
-    <ListPreference
-        android:defaultValue="1048576"
+        android:defaultValue="10485760"
         android:entries="@array/pref_download_size_titles"
         android:entryValues="@array/pref_download_size_values"
         android:key="@string/download_size"
@@ -22,6 +12,16 @@
         android:positiveButtonText="@null"
         android:summary="@string/pref_summary_download_size"
         android:title="@string/pref_title_download_size" />
+
+    <ListPreference
+        android:defaultValue="5242880"
+        android:entries="@array/pref_upload_size_titles"
+        android:entryValues="@array/pref_upload_size_values"
+        android:key="@string/upload_size"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null"
+        android:summary="@string/pref_summary_upload_size"
+        android:title="@string/pref_title_upload_size" />
 
     <ListPreference
         android:defaultValue="4"

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -27,6 +27,9 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 def artifactory_user = properties.getProperty("artifactory_user")
 def artifactory_password = properties.getProperty("artifactory_password")
 
+project.ext.googleMapsApiKey = properties.getProperty('google_maps_key')
+project.ext.googleDirectionsApiKey = properties.getProperty('google_directions_api_key')
+
 allprojects {
     apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'maven-publish'

--- a/mobiledgexsdkdemo/getdata.go
+++ b/mobiledgexsdkdemo/getdata.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ var (
 	indexpath   = "/"
 	getdatapath = "/getdata"
 	getfilepath = "/getfile"
+	uploaddatapath = "/uploaddata"
 	filedir     = "/root/downloadfiles/"
 )
 
@@ -49,7 +51,7 @@ func generateFiles() {
 
 func showIndex(w http.ResponseWriter, r *http.Request) {
 	log.Printf("doing showIndex req: %+v\n", r)
-	rc := getdatapath + "\n" + getfilepath + "\n"
+	rc := getdatapath + "\n" + getfilepath+ "\n" + uploaddatapath + "\n"
 
 	w.Write([]byte(rc))
 }
@@ -112,10 +114,26 @@ func getData(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(response))
 }
 
+func uploadData(w http.ResponseWriter, r *http.Request) {
+	log.Printf("doing uploadData %+v\n", r)
+	log.Printf("ContentLength= %+v\n", r.ContentLength)
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+			message := fmt.Sprintf("Error in ReadAll: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(message))
+			log.Printf(message)
+			return
+	}
+	log.Printf("Read %+v bytes from body\n", len(b))
+}
+
 func run() {
 	http.HandleFunc(indexpath, showIndex)
 	http.HandleFunc(getdatapath, getData)
 	http.HandleFunc(getfilepath, getFile)
+	http.HandleFunc(uploaddatapath, uploadData)
 
 	portstr := fmt.Sprintf(":%d", *port)
 
@@ -133,6 +151,6 @@ func validateArgs() {
 
 func main() {
 	validateArgs()
-	generateFiles()
+//	generateFiles()
 	run()
 }


### PR DESCRIPTION
- Added "UL SPEED TEST" to Cloudlet Details page.
- Removed dynamic/static download preference. Only dynamic will be used.
- New larger download preference values.
- Moved API key definition to local.properties, and added code to read them.

I meant to make the getdata.go code a separate PR, but it's only a single file, so I'm OK with it having slipped in here.