### PR TITLE
Get connection added to Android Workshop Completed

### DIFF
--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
@@ -18,26 +18,42 @@
 package com.mobiledgex.workshopskeleton;
 
 import android.content.Intent;
+import android.location.Location;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.view.WindowManager;
+import android.util.Log;
+
+import com.mobiledgex.matchingengine.AppConnectionManager;
+import com.mobiledgex.matchingengine.DmeDnsException;
+import com.mobiledgex.matchingengine.MatchingEngine;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import distributed_match_engine.AppClient;
+import distributed_match_engine.Appcommon;
 
 public class FaceProcessorActivity extends AppCompatActivity {
 
+    private static final String TAG = "FaceProcessorActivity";
     private FaceProcessorFragment mFaceProcessorFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.fragment_face_processor);
 
+        setContentView(R.layout.fragment_face_processor);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
         if (null == savedInstanceState) {
-            mFaceProcessorFragment = FaceProcessorFragment.newInstance();
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, mFaceProcessorFragment)
-                    .commit();
+            exampleDevloperWorkflowBackground();
         }
     }
 
@@ -55,6 +71,78 @@ public class FaceProcessorActivity extends AppCompatActivity {
         resultIntent.putExtra("STATS", stats);
         setResult(RESULT_OK, resultIntent);
         super.finish();
+    }
+
+    public Socket exampleDeveloperWorkflow() {
+        MatchingEngine me = new MatchingEngine(this);
+        AppConnectionManager appConnect = me.getAppConnectionManager();
+
+        String appName = "MobiledgeX SDK Demo";
+        String appVersion = "2.0";
+        String carrierName = "wifi";
+        String devName = "MobiledgeX";
+        Location location = new Location("MEX");
+        location.setLatitude(52.52);
+        location.setLongitude(13.4040);    //Berlin
+
+        Future<AppClient.FindCloudletReply> future = me.registerAndFindCloudlet(this, devName, appName, appVersion, carrierName, location, "", 0, "", "", null);
+        AppClient.FindCloudletReply findCloudletReply;
+        try {
+            findCloudletReply = future.get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.e(TAG, "RegisterAndFindCloudlet error " + e.getMessage());
+            return null;
+        }
+
+        HashMap<Integer, Appcommon.AppPort> portMap = appConnect.getTCPMap(findCloudletReply);
+        Appcommon.AppPort one = portMap.get(8008); // 8011 for persistent tcp
+
+        me.setNetworkSwitchingEnabled(true);
+        Future<Socket> fs = appConnect.getTcpSocket(findCloudletReply, one, one.getPublicPort(), 15000);
+        me.setNetworkSwitchingEnabled(false); // if using wifi only
+
+        if (fs == null) {
+            Log.e(TAG, "Socket future didnt return anything");
+            return null;
+        }
+
+        Socket socket;
+        try {
+            socket = fs.get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.e(TAG, "Cannot get socket from future. Exception: " + e.getMessage());
+            return null;
+        }
+        return socket;
+    }
+
+    private void exampleDevloperWorkflowBackground() {
+        // Creates new BackgroundRequest object which will call exampleDeveloperWorkflow
+        new ExampleDeveloperWorkflowBackgroundRequest().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    public class ExampleDeveloperWorkflowBackgroundRequest extends AsyncTask<Object, Void, Socket> {
+        @Override
+        protected Socket doInBackground(Object... params) {
+            return exampleDeveloperWorkflow();
+        }
+
+        @Override
+        protected void onPostExecute(Socket socket) {
+            if (socket != null) {
+                mFaceProcessorFragment = FaceProcessorFragment.newInstance();
+                mFaceProcessorFragment.mHost = socket.getInetAddress().getHostName();
+                mFaceProcessorFragment.mPort = socket.getPort();
+                getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.container, mFaceProcessorFragment)
+                        .commit();
+                try {
+                    socket.close();
+                } catch (IOException ioe) {
+                    Log.e(TAG, "Unable to close socket. IOException: " + ioe.getMessage());
+                }
+            }
+        }
     }
 
 }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
@@ -61,6 +61,9 @@ public class FaceProcessorFragment extends com.mobiledgex.computervision.ImagePr
     private TextView mStatusText;
     private Toolbar mCameraToolbar;
 
+    public String mHost;
+    public int mPort;
+
     public static FaceProcessorFragment newInstance() {
         return new FaceProcessorFragment();
     }
@@ -102,8 +105,7 @@ public class FaceProcessorFragment extends com.mobiledgex.computervision.ImagePr
 
         /////////////////////////////////////////////////////////////////////////////////////////////
         // TODO: Copy/paste the code to define an ImageSender
-        String host = mHostDetectionEdge; //The default from the base class.
-        mImageSenderEdge = new ImageSender(getActivity(), this, CloudletType.EDGE, host, FACE_DETECTION_HOST_PORT, PERSISTENT_TCP_PORT);
+        mImageSenderEdge = new ImageSender(getActivity(), this, CloudletType.CLOUD, mHost, mPort, PERSISTENT_TCP_PORT); // mHost and mPort come from GetConnectionWorkflow in FaceProcessorActivity
         mImageSenderEdge.setCameraMode(ImageSender.CameraMode.FACE_DETECTION);
         mCameraMode = ImageSender.CameraMode.FACE_DETECTION;
         mCameraToolbar.setTitle("Face Detection");

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -288,7 +288,7 @@ public class MainActivity extends AppCompatActivity
         host = matchingEngine.generateDmeHostAddress();
         if(host == null) {
             Log.e(TAG, "Could not generate host");
-            host = "sdkdemo.dme.mobiledgex.net";   //fallback host
+            host = "wifi.dme.mobiledgex.net";   //fallback host
         }
         port = matchingEngine.getPort(); // Keep same port.
         AppClient.RegisterClientRequest registerClientRequest;

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -564,7 +564,7 @@ public class MainActivity extends AppCompatActivity
         }
         // Ensures that user can switch from wifi to cellular network data connection (required to verifyLocation)
         matchingEngine = new MatchingEngine(ctx);
-        matchingEngine.setNetworkSwitchingEnabled(true);  //false-> wifi (Use wifi for demo)
+        matchingEngine.setNetworkSwitchingEnabled(false);  //false-> wifi (Use wifi for demo)
     }
 
     public class RegisterClientAndFindCloudletBackgroundRequest extends AsyncTask<Object, Void, Boolean> {


### PR DESCRIPTION
Add GetConnection workflow to FaceProcessorActivity.java.

Only the hostname and port of the socket that is returned from GetConnection is used when creating an ImageSender in FaceProcessorFragment.java. The socket is then closed after we pass its hostname and port and then we use the socket created in ImageSender.