### PR TITLE
Net interface update

### DIFF
--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
@@ -109,8 +109,7 @@ namespace MobiledgeXPingPongGame {
       // and a local DME cannot be located. Set to false if using a supported
       // SIM Card.
       integration = new MobiledgeXIntegration();
-      integration.useDemo = true;
-      integration.dmeHost = integration.me.GenerateDmeHostName();
+      integration.useWifiOnly(false);
 
       // Use local server, by IP. This must be started before use:
       if (useAltServer)

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/MobiledgeXIntegration.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/MobiledgeXIntegration.cs
@@ -53,13 +53,6 @@ public class MobiledgeXIntegration
   public string uniqueID { get; set; } = "";
   public Tag[] tags { get; set; } = new Tag[0];
 
-  // Override if there is a sdk demo DME host to use.
-  public string dmeHost { get; set; } = MatchingEngine.wifiOnlyDmeHost;
-  public uint dmePort { get; set; } = MatchingEngine.defaultDmeRestPort;
-
-  // Set to true and define the DME if there's no SIM card to find appropriate geolocated MobiledgeX DME (client is PC, UnityEditor, etc.)...
-  public bool useDemo { get; set; } = true;
-
   public MobiledgeXIntegration()
   {
     // Set the platform specific way to get SIM carrier information.
@@ -75,6 +68,11 @@ public class MobiledgeXIntegration
 
     // Optional NetTesting.
     netTest = new NetTest(me);
+  }
+
+  public void useWifiOnly(bool useWifi)
+  {
+    me.useOnlyWifi = useWifi;
   }
 
   public string GetCarrierName()
@@ -105,7 +103,7 @@ public class MobiledgeXIntegration
     // If MEX is reachable on your SIM card:
     string aCarrierName = GetCarrierName();
     string eCarrierName;
-    if (useDemo)
+    if (me.useOnlyWifi)
     {
       eCarrierName = carrierName;
     }
@@ -125,15 +123,7 @@ public class MobiledgeXIntegration
     Debug.Log("AppName: " + req.app_name);
     Debug.Log("AppVers: " + req.app_vers);
 
-    RegisterClientReply reply;
-    if (useDemo)
-    {
-      reply = await me.RegisterClient(dmeHost, dmePort, req);
-    }
-    else
-    {
-      reply = await me.RegisterClient(req);
-    }
+    RegisterClientReply reply = await me.RegisterClient(req);
 
     return (reply.status == ReplyStatus.RS_SUCCESS);
   }
@@ -148,7 +138,7 @@ public class MobiledgeXIntegration
     // If MEX is reachable on your SIM card:
     string aCarrierName = GetCarrierName();
     string eCarrierName;
-    if (useDemo) // There's no host (PC, UnityEditor, etc.)...
+    if (me.useOnlyWifi) // There's no host (PC, UnityEditor, etc.)...
     {
       eCarrierName = carrierName;
     }
@@ -164,15 +154,7 @@ public class MobiledgeXIntegration
 
     FindCloudletRequest req = me.CreateFindCloudletRequest(eCarrierName, devName, appName, appVers, loc, cellID, tags);
 
-    FindCloudletReply reply;
-    if (useDemo)
-    {
-      reply = await me.FindCloudlet(dmeHost, dmePort, req);
-    }
-    else
-    {
-      reply = await me.FindCloudlet(req);
-    }
+    FindCloudletReply reply = await me.FindCloudlet(req);
 
     return reply;
   }
@@ -184,7 +166,7 @@ public class MobiledgeXIntegration
     // If MEX is reachable on your SIM card:
     string aCarrierName = GetCarrierName();
     string eCarrierName;
-    if (useDemo) // There's no host (PC, UnityEditor, etc.)...
+    if (me.useOnlyWifi) // There's no host (PC, UnityEditor, etc.)...
     {
       eCarrierName = carrierName;
     }
@@ -195,15 +177,7 @@ public class MobiledgeXIntegration
 
     VerifyLocationRequest req = me.CreateVerifyLocationRequest(eCarrierName, loc, cellID, tags);
 
-    VerifyLocationReply reply;
-    if (useDemo)
-    {
-      reply = await me.VerifyLocation(dmeHost, dmePort, req);
-    }
-    else
-    {
-      reply = await me.VerifyLocation(req);
-    }
+    VerifyLocationReply reply = await me.VerifyLocation(req);
 
     // The return is not binary, but one can decide the particular app's policy
     // on pass or failing the location check. Not being verified or the country
@@ -247,7 +221,7 @@ public class MobiledgeXIntegration
 
     string aCarrierName = GetCarrierName();
     string eCarrierName;
-    if (useDemo)
+    if (me.useOnlyWifi)
     {
       eCarrierName = carrierName;
     }
@@ -261,15 +235,8 @@ public class MobiledgeXIntegration
       eCarrierName = aCarrierName;
     }
 
-    FindCloudletReply findCloudletReply;
-    if (useDemo)
-    {
-      findCloudletReply = await me.RegisterAndFindCloudlet(eCarrierName, devName, appName, appVers, developerAuthToken, loc, cellID, uniqueIDType, uniqueID, tags);
-    }
-    else
-    {
-      findCloudletReply = await me.RegisterAndFindCloudlet(dmeHost, dmePort, eCarrierName, devName, appName, appVers, developerAuthToken, loc, cellID, uniqueIDType, uniqueID, tags);
-    }
+    FindCloudletReply findCloudletReply = await me.RegisterAndFindCloudlet(eCarrierName, devName, appName, appVers, developerAuthToken, loc, cellID, uniqueIDType, uniqueID, tags);
+
     Dictionary<int, AppPort> appPortsDict = me.GetTCPAppPorts(findCloudletReply);
     int public_port = findCloudletReply.ports[0].public_port; // We happen to know it's the first one.
     AppPort appPort = appPortsDict[public_port];

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/PlatformIntegration/NetInterfaceIntegration.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/PlatformIntegration/NetInterfaceIntegration.cs
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-using System;
 using UnityEngine;
 using DistributedMatchEngine;
 
-// We need this one for importing our IOS functions
-using System.Runtime.InteropServices;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace MobiledgeXPingPongGame
 {
+  // A generic network interface for most systems, with an interface names parameter.
+  // The following is to allow Get{TCP, TLS, UDP}Connection APIs to return the configured
+  // edge network path to your MobiledgeX AppInsts. Other connections will use the system
+  // default network route. (NetInterfaceClass is used for MacOS and Linux)
   public class NetInterfaceClass : NetInterface
   {
     NetworkInterfaceName networkInterfaceName;
@@ -44,162 +46,80 @@ namespace MobiledgeXPingPongGame
       this.networkInterfaceName = networkInterfaceName;
     }
 
-#if UNITY_ANDROID
-
-    AndroidNetworkInterfaceName name = new AndroidNetworkInterfaceName();
-
-    AndroidJavaObject GetNetworkInterface(String netInterfaceType)
+    private NetworkInterface[] GetInterfaces()
     {
-      AndroidJavaClass networkInterfaceClass = PlatformIntegrationUtil.getAndroidJavaClass("java.net.NetworkInterface");
-      if (networkInterfaceClass == null)
+      return NetworkInterface.GetAllNetworkInterfaces();
+    }
+
+    public string GetIPAddress(string sourceNetInterfaceName, AddressFamily addressfamily = AddressFamily.InterNetwork)
+    {
+      if (!NetworkInterface.GetIsNetworkAvailable())
       {
-        Debug.Log("Unable to get network interface class");
         return null;
       }
 
-      object[] netParams = new object[1];
-      netParams[0] = netInterfaceType;
+      NetworkInterface[] netInterfaces = GetInterfaces();
 
-      AndroidJavaObject networkInterface = PlatformIntegrationUtil.callStatic(networkInterfaceClass, "getByName", netParams);
-      return networkInterface;
-    }
-
-    IntPtr GetInetAddress(AndroidJavaObject networkInterface)
-    {
-      AndroidJavaObject inetAddresses = PlatformIntegrationUtil.call(networkInterface, "getInetAddresses");
-      if (inetAddresses == null)
-      {
-        Debug.Log("Could not get inetAddresses");
-        return IntPtr.Zero;
-      }
-
-      IntPtr inetAddressesRaw = inetAddresses.GetRawObject();  // Get pointer to inetAddresses (Java enum), so that we can iterate through it
-      IntPtr inetAddressesClass = AndroidJNI.GetObjectClass(inetAddressesRaw);
-      if(inetAddressesClass == IntPtr.Zero)
-      {
-        Debug.Log("Could not get inetAddressesClass");
-        return IntPtr.Zero;
-      }
-
-      IntPtr nextMethod = AndroidJNIHelper.GetMethodID(inetAddressesClass, "nextElement");
-      if (nextMethod == IntPtr.Zero)
-      {
-        return IntPtr.Zero;
-      }
-
-      IntPtr inetAddress = AndroidJNI.CallObjectMethod(inetAddressesRaw, nextMethod, new jvalue[] { });
-      return inetAddress;
-    }
-
-    string GetHostAddress(IntPtr inetAddress)
-    {
-      IntPtr inetAddressClass = AndroidJNI.GetObjectClass(inetAddress);
-      IntPtr getHostAddressMethod = AndroidJNIHelper.GetMethodID(inetAddressClass, "getHostAddress");
-
-      String ipAddress = AndroidJNI.CallStringMethod(inetAddress, getHostAddressMethod, new jvalue[] { });
-      return ipAddress;
-    }
-
-    string GetNetworkInterfaceIP(String netInterfaceType)
-    {
-      AndroidJavaObject networkInterface = GetNetworkInterface(netInterfaceType);
-      if (networkInterface == null)
-      {
-        return "";
-      }
-
-      IntPtr inetAddress = GetInetAddress(networkInterface);
-      if (inetAddress == IntPtr.Zero)
-      {
-        return "";
-      }
-
-      String ipAddress = GetHostAddress(inetAddress);
-      return ipAddress;
-    }
-
-    public string GetIPAddress(String netInterfaceType, AddressFamily adressFamily = AddressFamily.InterNetwork)
-    {
-      return GetNetworkInterfaceIP(netInterfaceType);
-    }
-
-    public bool HasWifi()
-    {
-      if (GetNetworkInterfaceIP(name.WIFI) != "")
-      {
-        return true;
-      }
-      return false;
-    }
-
-    public bool HasCellular()
-    {
-      if (GetNetworkInterfaceIP(name.CELLULAR) != "")
-      {
-        return true;
-      }
-      return false;
-    }
-
-#elif UNITY_IOS
-
-    [DllImport("__Internal")]
-    private static extern string _getIPAddress(string netInterfaceType);
-
-    [DllImport("__Internal")]
-    private static extern bool _isWifi();
-
-    [DllImport("__Internal")]
-    private static extern bool _isCellular();
-
-    public string GetIPAddress(String netInterfaceType, AddressFamily adressFamily = AddressFamily.InterNetwork)
-    {
       string ipAddress = null;
-      if (Application.platform == RuntimePlatform.IPhonePlayer)
+      string ipAddressV4 = null;
+      string ipAddressV6 = null;
+      Debug.Log("Looking for: " + sourceNetInterfaceName + ", known Wifi: " + networkInterfaceName.WIFI + ", known Cellular: " + networkInterfaceName.CELLULAR);
+
+      foreach (NetworkInterface iface in netInterfaces)
       {
-        ipAddress = _getIPAddress(netInterfaceType);
+        if (iface.Name.Equals(sourceNetInterfaceName))
+        {
+          IPInterfaceProperties ipifaceProperties = iface.GetIPProperties();
+          foreach (UnicastIPAddressInformation ip in ipifaceProperties.UnicastAddresses)
+          {
+            if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
+            {
+              ipAddressV4 = ip.Address.ToString();
+            }
+            if (ip.Address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+              ipAddressV6 = ip.Address.ToString();
+            }
+          }
+
+          if (addressfamily == AddressFamily.InterNetworkV6)
+          {
+            return ipAddressV6;
+          }
+
+          if (addressfamily == AddressFamily.InterNetwork)
+          {
+            return ipAddressV4;
+          }
+        }
       }
       return ipAddress;
     }
 
-    public bool HasWifi()
-    {
-      bool isWifi = false;
-      if (Application.platform == RuntimePlatform.IPhonePlayer)
-      {
-        isWifi = _isWifi();
-      }
-      return isWifi;
-    }
-
     public bool HasCellular()
     {
-      bool isCellular = false;
-      if (Application.platform == RuntimePlatform.IPhonePlayer)
+      NetworkInterface[] netInterfaces = GetInterfaces();
+      foreach (NetworkInterface iface in netInterfaces)
       {
-        isCellular = _isCellular();
+        if (iface.Name.Equals(networkInterfaceName.CELLULAR))
+        {
+          return iface.OperationalStatus == OperationalStatus.Up;
+        }
       }
-      return isCellular;
-    }
-
-#else
-    public string GetIPAddress(String netInterfaceType, AddressFamily adressFamily = AddressFamily.InterNetwork)
-    {
-      Debug.Log("GetIPAddress is NOT IMPLEMENTED");
-      return null;
+      return false;
     }
 
     public bool HasWifi()
     {
-      Debug.Log("HasWifi is NOT IMPLEMENTED");
+      NetworkInterface[] netInterfaces = GetInterfaces();
+      foreach (NetworkInterface iface in netInterfaces)
+      {
+        if (iface.Name.Equals(networkInterfaceName.WIFI))
+        {
+          return iface.OperationalStatus == OperationalStatus.Up;
+        }
+      }
       return false;
     }
-
-    public bool HasCellular()
-    {
-      Debug.Log("HasCellular is NOT IMPLEMENTED");
-      return false;
-    }
-#endif
   }
 }


### PR DESCRIPTION
1) Removed useDemo which is the same as useWifiOnly
2) Replaced AndroidJNI code for NetInterface with Garner's SimpleNetInterface from c# sdk. Didn't realize we could pull that information directly with C# code. This fixes the weird crash we had when NetTest was running (probably some issue/ uncaught exception with the AndroidJNI code)