### PR TITLE
Abort init on db operations

### DIFF
--- a/FaceDetectionServer/moedx/tracker/apps.py
+++ b/FaceDetectionServer/moedx/tracker/apps.py
@@ -13,14 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# If this script is called by manage.py with with either "makemigrations" or "migrate",
+# we don't need to continue with initialization.
+import sys
+import logging
+if len(sys.argv) >= 2 and sys.argv[0] == "manage.py" and "migrat" in sys.argv[1]:
+    logger.warning("Called by '%s %s'. Aborting app initialization." %(sys.argv[0], sys.argv[1]))
+    sys.exit()
+
 from django.apps import AppConfig
 from facial_detection.face_detector import FaceDetector
 from facial_detection.face_recognizer import FaceRecognizer
 from facial_detection.tcp_server import ThreadedTCPServer, ThreadedTCPRequestHandler
 from object_detection.object_detector import ObjectDetector
 import threading
-import logging
-import sys
 import time
 import os
 

--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 54
-        versionName "1.1.5"
+        versionCode 55
+        versionName "1.1.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/release/output.json
+++ b/android/MobiledgeXSDKDemo/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":53,"versionName":"1.1.4","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":54,"versionName":"1.1.5","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release"},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -87,6 +87,8 @@ public class Cloudlet implements Serializable {
     private String mFqdnPrefix;
     private String mIpAddress;
     private String uri;
+    private CloudletListHolder.LatencyTestMethod mLatencyTestMethod;
+    private boolean mLatencyTestMethodForced = false;
 
     public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String uri, Marker marker, String fqdnPrefix, int port) {
         Log.d(TAG, "Cloudlet contructor. cloudletName="+cloudletName);
@@ -98,6 +100,8 @@ public class Cloudlet implements Serializable {
         } else {
             Log.i(TAG, "LatencyTestAutoStart is disabled");
         }
+
+        mLatencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
     }
 
     public void update(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String uri, Marker marker, String fqdnPrefix, int port) {
@@ -183,22 +187,24 @@ public class Cloudlet implements Serializable {
             Log.i(TAG, "NO, I am NOT an emulator.");
         }
 
-        CloudletListHolder.LatencyTestMethod latencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
+        mLatencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
         if(mCarrierName.equalsIgnoreCase("azure")) {
             Log.i(TAG, "Socket test forced for Azure");
-            latencyTestMethod = CloudletListHolder.LatencyTestMethod.socket;
+            mLatencyTestMethod = CloudletListHolder.LatencyTestMethod.socket;
+            mLatencyTestMethodForced = true;
         }
         if(runningOnEmulator) {
             Log.i(TAG, "Socket test forced for emulator");
-            latencyTestMethod = CloudletListHolder.LatencyTestMethod.socket;
+            mLatencyTestMethod = CloudletListHolder.LatencyTestMethod.socket;
+            mLatencyTestMethodForced = true;
         }
 
-        if (latencyTestMethod == CloudletListHolder.LatencyTestMethod.socket) {
+        if (mLatencyTestMethod == CloudletListHolder.LatencyTestMethod.socket) {
             new LatencyTestTaskSocket().execute();
-        } else if (latencyTestMethod == CloudletListHolder.LatencyTestMethod.ping) {
+        } else if (mLatencyTestMethod == CloudletListHolder.LatencyTestMethod.ping) {
             new LatencyTestTaskPing().execute();
         } else {
-            Log.e(TAG, "Unknown latencyTestMethod: " + latencyTestMethod);
+            Log.e(TAG, "Unknown mLatencyTestMethod: " + mLatencyTestMethod);
         }
     }
 
@@ -662,6 +668,13 @@ public class Cloudlet implements Serializable {
         return mFqdnPrefix;
     }
 
+    public CloudletListHolder.LatencyTestMethod getLatencyTestMethod() {
+        return mLatencyTestMethod;
+    }
+
+    public boolean getLatencyTestMethodForced() {
+        return mLatencyTestMethodForced;
+    }
 
 
 }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -191,12 +191,11 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
             @Override
             public void run() {
                 CloudletListHolder.LatencyTestMethod latencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
-                latencyMessageTv.setText("Method: "+latencyTestMethod.name());
-                if(cloudlet.getCarrierName().equalsIgnoreCase("azure")) {
-                    if(latencyTestMethod == CloudletListHolder.LatencyTestMethod.ping) {
-                        latencyMessageTv.setText("Socket test forced");
-                    }
+                String latencyMessage = "Method: "+cloudlet.getLatencyTestMethod();
+                if (cloudlet.getLatencyTestMethodForced()) {
+                    latencyMessage += " (forced)";
                 }
+                latencyMessageTv.setText(latencyMessage);
 
                 if(cloudlet.getLatencyMin() != 9999) {
                     latencyMinTv.setText(formatValue(cloudlet.getLatencyMin()) + " ms");

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -104,6 +104,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -1092,10 +1094,13 @@ public class MainActivity extends AppCompatActivity
                 return;
             }
 
+            DateFormat format = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.SHORT, Locale.getDefault());
+            String currentDateTime = format.format(new Date());
+
             String stats = data.getExtras().getString("STATS");
             // The TextView to show your Text
             TextView showText = new TextView(MainActivity.this);
-            showText.setText(stats);
+            showText.setText(currentDateTime + "\n" + stats);
             showText.setTextIsSelectable(true);
             int horzPadding = (int) (15 * getResources().getDisplayMetrics().density);
             showText.setPadding(horzPadding, 0,horzPadding,0);

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // JFrog Artifactory:

--- a/android/MobiledgeXSDKDemo/computervision/build.gradle
+++ b/android/MobiledgeXSDKDemo/computervision/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     implementation project(':opencv')
     implementation 'com.android.volley:volley:1.1.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.2.1'
     implementation 'com.google.android.gms:play-services-auth:16.0.1'
     implementation "com.mobiledgex:matchingengine:${matchingengineVersion}"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"

--- a/android/MobiledgeXSDKDemo/computervision/src/androidTest/java/com/mobiledgex/computervision/ComputerVisionRestUnitTest.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/androidTest/java/com/mobiledgex/computervision/ComputerVisionRestUnitTest.java
@@ -1,6 +1,7 @@
 package com.mobiledgex.computervision;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.location.Location;
@@ -126,6 +127,9 @@ public class ComputerVisionRestUnitTest {
             return null;
         } catch (InterruptedException ie) {
             Log.e(TAG, "InterruptedException registering client. " + ie.getMessage());
+            return null;
+        } catch (PackageManager.NameNotFoundException nnfe) {
+            Log.e(TAG, "InterruptedException registering client. " + nnfe.getMessage());
             return null;
         }
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -400,6 +400,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             menu.findItem(R.id.action_benchmark_local).setVisible(false);
             menu.findItem(R.id.action_benchmark_submenu).setVisible(false);
         }
+
     }
 
     @Override
@@ -722,9 +723,30 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
         mEdgeFaceBoxRenderer.setStrokeWidth(strokeWidth);
         mLocalFaceBoxRenderer.setStrokeWidth(strokeWidth);
 
-        mImageSenderCloud = new ImageSender(getActivity(), this, CloudletType.CLOUD, mHostDetectionCloud, FACE_DETECTION_HOST_PORT, PERSISTENT_TCP_PORT);
-        mImageSenderEdge = new ImageSender(getActivity(), this, CloudletType.EDGE, mHostDetectionEdge, FACE_DETECTION_HOST_PORT, PERSISTENT_TCP_PORT);
-        mImageSenderTraining = new ImageSender(getActivity(), this, CloudletType.PUBLIC, mHostTraining, FACE_TRAINING_HOST_PORT, PERSISTENT_TCP_PORT);
+        mImageSenderCloud = new ImageSender.Builder()
+                .setActivity(getActivity())
+                .setImageServerInterface(this)
+                .setCloudLetType(CloudletType.CLOUD)
+                .setHost(mHostDetectionCloud)
+                .setPort(FACE_DETECTION_HOST_PORT)
+                .setPersistentTcpPort(PERSISTENT_TCP_PORT)
+                .build();
+        mImageSenderEdge = new ImageSender.Builder()
+                .setActivity(getActivity())
+                .setImageServerInterface(this)
+                .setCloudLetType(CloudletType.EDGE)
+                .setHost(mHostDetectionEdge)
+                .setPort(FACE_DETECTION_HOST_PORT)
+                .setPersistentTcpPort(PERSISTENT_TCP_PORT)
+                .build();
+        mImageSenderTraining = new ImageSender.Builder()
+                .setActivity(getActivity())
+                .setImageServerInterface(this)
+                .setCloudLetType(CloudletType.PUBLIC)
+                .setHost(mHostTraining)
+                .setPort(FACE_TRAINING_HOST_PORT)
+                .setPersistentTcpPort(PERSISTENT_TCP_PORT)
+                .build();
 
         boolean faceRecognition = intent.getBooleanExtra(EXTRA_FACE_RECOGNITION, false);
         if (faceRecognition) {
@@ -741,6 +763,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
 
         //One more call to get preferences for ImageSenders
         onSharedPreferenceChanged(prefs, "ALL");
+
     }
 
     protected void toggleViews() {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -228,12 +228,19 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
             mHostDetectionEdge = edgeCloudletHostname;
         }
         
-        mImageSenderEdge = new ImageSender(getActivity(),this, CloudletType.EDGE, mHostDetectionEdge, FACE_DETECTION_HOST_PORT, PERSISTENT_TCP_PORT);
+        mImageSenderEdge = new ImageSender.Builder()
+                .setActivity(getActivity())
+                .setImageServerInterface(this)
+                .setCloudLetType(CloudletType.EDGE)
+                .setHost(mHostDetectionEdge)
+                .setPort(FACE_DETECTION_HOST_PORT)
+                .setPersistentTcpPort(PERSISTENT_TCP_PORT)
+                .setCameraMode(ImageSender.CameraMode.OBJECT_DETECTION)
+                .build();
 
         //TODO: Revisit when we have GPU support on multiple servers.
         //The only GPU-enabled server we have doesn't support ping.
         mImageSenderEdge.setLatencyTestMethod(ImageSender.LatencyTestMethod.socket);
-        mImageSenderEdge.setCameraMode(ImageSender.CameraMode.OBJECT_DETECTION);
         mCameraMode = ImageSender.CameraMode.OBJECT_DETECTION;
         mCameraToolbar.setTitle(R.string.title_activity_object_detection);
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -235,12 +235,19 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
         mPoseRenderer.setStrokeWidth(strokeWidth);
         mPoseRenderer.setJointRadius(jointRadius);
 
-        mImageSenderEdge = new ImageSender(getActivity(),this, CloudletType.EDGE, mHostDetectionEdge, FACE_DETECTION_HOST_PORT, PERSISTENT_TCP_PORT);
+        mImageSenderEdge = new ImageSender.Builder()
+                .setActivity(getActivity())
+                .setImageServerInterface(this)
+                .setCloudLetType(CloudletType.EDGE)
+                .setHost(mHostDetectionEdge)
+                .setPort(FACE_DETECTION_HOST_PORT)
+                .setPersistentTcpPort(PERSISTENT_TCP_PORT)
+                .setCameraMode(ImageSender.CameraMode.POSE_DETECTION)
+                .build();
 
         //TODO: Revisit when we have GPU support on multiple servers.
         //The only GPU-enabled server we have doesn't support ping.
         mImageSenderEdge.setLatencyTestMethod(ImageSender.LatencyTestMethod.socket);
-        mImageSenderEdge.setCameraMode(ImageSender.CameraMode.POSE_DETECTION);
         mCameraMode = ImageSender.CameraMode.POSE_DETECTION;
         mCameraToolbar.setTitle(R.string.title_activity_pose_detection);
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -84,10 +84,12 @@
     <string-array name="pref_fd_connection_mode_titles">
         <item>REST</item>
         <item>Persistent TCP</item>
+        <item>WebSocket</item>
     </string-array>
     <string-array name="pref_fd_connection_mode_values">
         <item>REST</item>
         <item>PERSISTENT_TCP</item>
+        <item>WEBSOCKET</item>
     </string-array>
 
 </resources>

--- a/android/MobiledgeXSDKDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/android/MobiledgeXSDKDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 30 11:48:30 CDT 2019
+#Wed Apr 01 11:45:49 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
When apps.py is called by "manage.py makemigrations" or "manage.py migrate", abort initialization. This will eliminate lots of extraneous output during "make", but more importantly, speed up builds.