### PR TITLE
EDGECLOUD-2435 - Do not perform app initialization for manage.py

### DIFF
--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -158,7 +158,7 @@ class Client:
             return
 
         if self.stats_latency_full_process.n > 0:
-            logger.info("====> Average Latency Network Only=%.3f ms (stddev=%.3f)" %(self.stats_latency_full_process.mean(), self.stats_latency_full_process.stddev()))
+            logger.info("====> Average Latency Full Process=%.3f ms (stddev=%.3f)" %(self.stats_latency_full_process.mean(), self.stats_latency_full_process.stddev()))
         if self.stats_latency_network_only.n > 0:
             logger.info("====> Average Latency Network Only=%.3f ms (stddev=%.3f)" %(self.stats_latency_network_only.mean(), self.stats_latency_network_only.stddev()))
         if self.stats_server_processing_time.n > 0:
@@ -420,7 +420,7 @@ if __name__ == "__main__":
         logger.info(header2)
         logger.info(separator)
         if Client.stats_latency_full_process.n > 0:
-            logger.info("====> Average Latency Network Only=%.3f ms (stddev=%.3f)" %(Client.stats_latency_full_process.mean(), Client.stats_latency_full_process.stddev()))
+            logger.info("====> Average Latency Full Process=%.3f ms (stddev=%.3f)" %(Client.stats_latency_full_process.mean(), Client.stats_latency_full_process.stddev()))
         if Client.stats_latency_network_only.n > 0:
             logger.info("====> Average Latency Network Only=%.3f ms (stddev=%.3f)" %(Client.stats_latency_network_only.mean(), Client.stats_latency_network_only.stddev()))
         if Client.stats_server_processing_time.n > 0:

--- a/FaceDetectionServer/moedx/tracker/apps.py
+++ b/FaceDetectionServer/moedx/tracker/apps.py
@@ -13,18 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# If this script is called by manage.py with with either "makemigrations" or "migrate",
+# we don't need to continue with initialization.
+import sys
+import logging
+logger = logging.getLogger(__name__)
+if len(sys.argv) >= 2 and sys.argv[0] == "manage.py" and "migrat" in sys.argv[1]:
+    logger.info("Called by '%s %s'. Aborting app initialization." %(sys.argv[0], sys.argv[1]))
+    sys.exit()
+
 from django.apps import AppConfig
 from facial_detection.face_detector import FaceDetector
 from facial_detection.face_recognizer import FaceRecognizer
 from facial_detection.tcp_server import ThreadedTCPServer, ThreadedTCPRequestHandler
 from object_detection.object_detector import ObjectDetector
 import threading
-import logging
-import sys
 import time
 import os
-
-logger = logging.getLogger(__name__)
 
 PERSISTENT_TCP_PORT_DEFAULT = 8011 # Can be overridden with envvar FD_PERSISTENT_TCP_PORT
 


### PR DESCRIPTION
When apps.py is called by "manage.py makemigrations" or "manage.py migrate", abort initialization. This removes the warning in the bug that is referenced, but also cleans up a lot of extraneous output during the build and speeds up the build.