### PR TITLE
EDGECLOUD-2446 - Auto update submodule

### DIFF
--- a/FaceDetectionServer/Makefile
+++ b/FaceDetectionServer/Makefile
@@ -10,7 +10,11 @@ endif
 
 default: docker-build docker-push
 
-docker-build:
+submodule-update:
+	git submodule init
+	git submodule update
+
+docker-build: submodule-update
 	docker build -t mobiledgex/mobiledgexsdkdemo20:${TAG} -f $(DOCKERFILE) .
 
 docker-push:


### PR DESCRIPTION
The Jira bug says to clarify the error, but this update gets rid of the error by automatically updating the submodule whether the steps were done manually or not.