### PR TITLE
EDGECLOUD-2435 Do not exit. Allow db init.

### DIFF
--- a/FaceDetectionServer/moedx/tracker/consumers.py
+++ b/FaceDetectionServer/moedx/tracker/consumers.py
@@ -34,9 +34,6 @@ class ImageConsumerFaceDetector(WebsocketConsumer):
     def connect(self):
         self.accept()
         logger.info("ImageConsumerFaceDetector")
-        logger.info("keys: %s" %self.scope.keys())
-        logger.info("items: %s" %self.scope.items())
-        logger.info("values: %s" %self.scope.values())
 
     def disconnect(self, close_code):
         logger.info("disconnect. close_code=%s" %close_code)


### PR DESCRIPTION
- Previous fix exited too soon, and did not allow db initialization. This update doesn't import the detect/recognize classes in the case of manage.py db init calls.
- Cleanup for multi_client.py when show-responses is false.
