### PR TITLE
EDGECLOUD-2447 Remove db access code from init function

### DIFF
--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -188,7 +188,7 @@ class RestClient(Client):
             content = response.content
             if response.status_code != 200:
                 logger.error("non-200 response: %d: %s" %(response.status_code, content))
-                return
+                continue
             self.process_result(content)
 
             if (x+1) % PING_INTERVAL == 0:

--- a/FaceDetectionServer/moedx/facial_detection/face_recognizer.py
+++ b/FaceDetectionServer/moedx/facial_detection/face_recognizer.py
@@ -73,7 +73,7 @@ class FaceRecognizer(object):
         # of /recognizer/predict.
 
     def training_data_startup(self):
-        logger.info("traing_data_startup()")
+        logger.info("training_data_startup()")
         try:
             while self.is_update_in_progress():
                 logger.info("Sleeping while another worker updates training data")
@@ -270,7 +270,7 @@ class FaceRecognizer(object):
 
     def set_db_timestamps(self, last_download_timestamp=None):
         from tracker.models import CentralizedTraining
-        ct = CentralizedTraining.objects.get(
+        ct, created = CentralizedTraining.objects.get_or_create(
             server_name = self.training_data_hostname)
         ct.last_check_timestamp = time.time()
         if last_download_timestamp != None:

--- a/FaceDetectionServer/moedx/facial_detection/face_recognizer.py
+++ b/FaceDetectionServer/moedx/facial_detection/face_recognizer.py
@@ -66,6 +66,14 @@ class FaceRecognizer(object):
         self.training_data_auth = HTTPBasicAuth('mexf4ceuser555', 'p4ssw0dmexf4c3999')
         self.training_data_timestamp = 0
 
+        # self.training_data_startup()
+        # This is commented out because at startup, uvicorn calls this __init__
+        # function in async mode, and db access is not allowed. Training data
+        # will be checked for updates, and downloaded if necessary on first call
+        # of /recognizer/predict.
+
+    def training_data_startup(self):
+        logger.info("traing_data_startup()")
         try:
             while self.is_update_in_progress():
                 logger.info("Sleeping while another worker updates training data")

--- a/FaceDetectionServer/moedx/tracker/views.py
+++ b/FaceDetectionServer/moedx/tracker/views.py
@@ -172,6 +172,7 @@ def recognizer_update(request):
     logger.debug(prepend_ip("Request received: %s" %request, request))
     if request.method != 'POST':
         return HttpResponseBadRequest("Must send request as a POST")
+
     ret = myFaceRecognizer.download_training_data_if_needed()
     return HttpResponse("%s\n" %ret)
 
@@ -417,4 +418,3 @@ def object_detect(request):
     logger.info(prepend_ip("%s ms to detect objects: %s" %(elapsed, ret), request))
     json_ret = json.dumps(ret)
     return HttpResponse(json_ret)
-


### PR DESCRIPTION
When I added websocket support, I switched from the Gunicorn web server to Uvicorn. This server supports async functions, and it also calls the class __init__ functions in async mode. Because Django database access is not allowed on an async thread, the code fails, and the training data download does not occur at startup.

The update will occur when face recognition is started, although there will be a delay in processing the first frame while the update happens. This won't affect latency stats though, because a 503/Unavailable is returned while the update is in progress.

I moved the initial training data download code out of __init__ and into its own function, then commented out the call so the "cannot call this from an async context" is no longer seen.

Note that all of this training data handling will completely change if/when we add Redis db to distribute training images.