### PR TITLE
EDGECLOUD-2575: Unity: IsEdgeAvailable()

### DIFF
--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
@@ -207,7 +207,17 @@ namespace MobiledgeXPingPongGame {
       }
       else
       {
-        await client.Connect(queryParams);
+        try
+        {
+          await client.Connect(queryParams);
+        }
+        catch (Exception e)
+        {
+          clog("Unable to get websocket connection. Exception: " + e.Message  + ". Switching to AltServer.");
+          useAltServer = true;
+          ConnectToServerWithRoomId(roomId);
+          return;
+        }
       }
       clog("Connection to status: " + client.isOpen());
     }

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/MobiledgeXIntegration.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/Integration/MobiledgeXIntegration.cs
@@ -240,7 +240,6 @@ public class MobiledgeXIntegration
   // Edge requires connections to run over cellular interface
   public  bool IsEdgeEnabled(GetConnectionProtocols proto)
   {
-    me.useOnlyWifi = false;
     if (me.useOnlyWifi)
     {
       Debug.Log("useOnlyWifi must be false to enable edge connection");


### PR DESCRIPTION
1) add IsEdgeEnabled check
- If GetConnectionProtocols is TCP or UDP, this will check if device HasCellular() and if the ip address bound to cellular interface exists. 
- If the GetConnectionProtocols is HTTP or Websockets, this will check if device HasCellular() and does not HasWifi(). This is because we do not have control of the local interface with these protocols, and they default to wifi if it is up. We also check to make sure the ip address bound to the cellular interface exists.

2) Throw exceptions from GetWebsocketConnection() if IsEdgeEnabled is false. Catch the exception in GameManager.cs (wsClient.Connect()) and useAltServer and call ConnectToServerWithRoomId() again if we cannot connect.

Exception: 
`Unable to get websocket connection. Exception: Device is not edge enabled. Please switch to cellular connection or use server in public cloud. Switching to AltServer.`

TODO:
- Move over to c# SDK instead of MobiledgeXIntegration
- Better handling of IsEdgeEnabled per protocol
- Support this in Swift