### PR TITLE
EDGECLOUD-2618 Video and server usage support

### DIFF
--- a/FaceDetectionServer/Dockerfile
+++ b/FaceDetectionServer/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp
 RUN pip install -r requirements.txt
 # Download weights file required for object detection
 WORKDIR /usr/src/app/moedx/pytorch_objectdetecttrack/config
-RUN wget https://pjreddie.com/media/files/yolov3.weights
+RUN wget http://opencv.facetraining.mobiledgex.net/files/yolov3.weights
 WORKDIR /usr/src/app/moedx
 # Initialize the database.
 RUN python manage.py makemigrations tracker

--- a/FaceDetectionServer/Dockerfile_openpose
+++ b/FaceDetectionServer/Dockerfile_openpose
@@ -29,7 +29,7 @@ WORKDIR /tmp
 RUN pip3 install -r requirements.txt
 # Download weights file required for object detection
 WORKDIR /usr/src/app/moedx/pytorch_objectdetecttrack/config
-RUN wget https://pjreddie.com/media/files/yolov3.weights
+RUN wget http://opencv.facetraining.mobiledgex.net/files/yolov3.weights
 WORKDIR /usr/src/app/moedx
 COPY . /usr/src/app
 # Initialize the database.

--- a/FaceDetectionServer/README.md
+++ b/FaceDetectionServer/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 cd moedx/
 python manage.py makemigrations tracker
 python manage.py migrate
-gunicorn moedx.wsgi:application --bind 0.0.0.0:8008
+uvicorn moedx.asgi:application --host 0.0.0.0 --port 8008
 ```
 ### How to install OpenPose on a GPU-enabled server
 This assumes CUDA and CUDNN are already installed.

--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -30,6 +30,7 @@ import struct
 import json
 import time
 import logging
+import cv2
 from threading import Thread
 from utils import RunningStats
 
@@ -82,18 +83,53 @@ class Client:
         self.filename_list_index = 0
         self.json_params = None
         self.base64 = False
+        self.video = None
+        self.resize_w = 180
+        self.resize_h = 240
         logger.debug("host:port = %s:%d" %(self.host, self.port))
 
     def start(self):
-        logger.debug("image file(s) %s %s" %(self.image_file_name, self.filename_list))
+        logger.debug("image file(s) %s" %(self.filename_list))
+        video_extensions = ('mp4','avi', 'mov')
+        if self.filename_list[0].endswith(video_extensions):
+            logger.debug("It's a video")
+            self.image_file_name = self.filename_list[0]
+            self.video = cv2.VideoCapture(self.image_file_name)
 
-    def next_file_name(self):
-        """ If the filename_list array is has more than 1, get the next value. """
-        if len(self.filename_list) > 1:
-            self.filename_list_index += 1
-            if self.filename_list_index >= len(self.filename_list):
+    def get_next_image(self):
+        if self.video is not None:
+            ret, image = self.video.read()
+            if not ret:
+                logger.debug("End of video")
+                return None
+            vw = image.shape[1]
+            vh = image.shape[0]
+            logger.debug("Video size: %dx%d" %(vw,vh))
+            image = cv2.resize(image, (self.resize_w, self.resize_h))
+            res, image = cv2.imencode('.JPEG', image)
+            image = image.tostring()
+        else:
+            # If the filename_list array has more than 1, get the next value.
+            if len(self.filename_list) > 1:
+                self.filename_list_index += 1
+                if self.filename_list_index >= len(self.filename_list):
+                    self.filename_list_index = 0
+            else:
                 self.filename_list_index = 0
+
+            if self.stats_latency_full_process.n >= self.num_repeat:
+                return None
+
             self.image_file_name = self.filename_list[self.filename_list_index]
+            with open(self.image_file_name, "rb") as f:
+                image = f.read()
+
+        logger.debug("Image data (first 32 bytes logged): %s" %image[:32])
+        return image
+
+    def get_server_stats(self):
+        url = "http://%s:%d%s" %(self.host, self.port, "/server/usage/")
+        logger.info(requests.get(url).content)
 
     def time_open_socket(self):
         now = time.time()
@@ -133,7 +169,12 @@ class Client:
 
     def process_result(self, result):
         global TEST_PASS
-        decoded_json = json.loads(result)
+        try:
+            decoded_json = json.loads(result)
+        except Exception as e:
+            logger.error("Could not decode result. Exception: %s. Result: %s" %(e, result))
+            TEST_PASS = False
+            return
         if 'success' in decoded_json:
             if decoded_json['success'] == "true":
                 TEST_PASS = True
@@ -177,9 +218,11 @@ class RestClient(Client):
         Client.start(self)
         self.url = "http://%s:%d%s" %(self.host, self.port, self.endpoint)
 
-        for x in range(self.num_repeat):
-            with open(self.image_file_name, "rb") as f:
-                image = f.read()
+        while True:
+            image = self.get_next_image()
+            if image is None:
+                break
+
             self.latency_start_time = time.time()
             if self.base64:
                 response = self.send_image_json(image)
@@ -191,13 +234,13 @@ class RestClient(Client):
                 continue
             self.process_result(content)
 
-            if (x+1) % PING_INTERVAL == 0:
+            if (self.stats_latency_full_process.n) % PING_INTERVAL == 0:
+                if self.do_server_stats:
+                    self.get_server_stats()
                 if self.net_latency_method == "SOCKET":
                     self.time_open_socket()
                 else:
                     self.icmp_ping()
-
-            self.next_file_name()
 
         logger.debug("Done")
         self.display_results()
@@ -206,7 +249,8 @@ class RestClient(Client):
         """
         Sends the raw image data with a 'Content-Type' of 'image/jpeg'.
         """
-        headers = {'Content-Type': 'image/jpeg'}
+        # headers = {'Content-Type': 'image/jpeg'}
+        headers = {'Content-Type': 'image/jpeg', "Mobiledgex-Debug": "true"} # Enable saving debug images
         return requests.post(self.url, data=image, headers=headers)
 
     def send_image_json(self, image):
@@ -247,9 +291,11 @@ class PersistentTcpClient(Client):
         sock.connect((self.host, self.port))
 
         logger.debug("repeating %s %d times" %(op_code, self.num_repeat))
-        for x in range(self.num_repeat):
-            with open(self.image_file_name, "rb") as f:
-                data = f.read()
+        while True:
+            data = self.get_next_image()
+            if data is None:
+                break
+
             length = len(data)
             logger.debug("data length = %d" %length)
             self.latency_start_time = time.time()
@@ -262,13 +308,13 @@ class PersistentTcpClient(Client):
             result = str(sock.recv(length), "utf-8")
 
             self.process_result(result)
-            if (x+1) % PING_INTERVAL == 0:
+            if (self.stats_latency_full_process.n) % PING_INTERVAL == 0:
+                if self.do_server_stats:
+                    self.get_server_stats()
                 if self.net_latency_method == "SOCKET":
                     self.time_open_socket()
                 else:
                     self.icmp_ping()
-
-            self.next_file_name()
 
         logger.debug("Done")
         self.display_results()
@@ -305,14 +351,11 @@ class WebSocketClient(Client):
         # logger.info("on_message: %s loop_count: %s", %(message,self.loop_count))
         self.process_result(message)
 
-        if self.stats_latency_full_process.n >= self.num_repeat:
-            logger.debug("repeating done")
-            self.display_results()
-            ws.close()
-            return
-
         self.loop_count += 1
         if self.loop_count % (PING_INTERVAL+1) == 0:
+            if self.do_server_stats:
+                self.get_server_stats()
+
             # ignore self.net_latency_method because any other type of
             # network activity seems to lock up the websocket.
 
@@ -321,10 +364,13 @@ class WebSocketClient(Client):
             ws.send(payload)
             return
 
-        self.next_file_name()
-        logger.debug("image_file_name: %s filename_list_index: %s num_repeat: %s count_latency_full_process: %s" %(self.image_file_name, self.filename_list_index, self.num_repeat, self.stats_latency_full_process.n))
-        with open(self.image_file_name, "rb") as f:
-            image = f.read()
+        image = self.get_next_image()
+        if image is None:
+            logger.debug("repeating done")
+            self.display_results()
+            ws.close()
+            return
+        logger.debug("loop_count: %d image_file_name: %s filename_list_index: %s num_repeat: %s count_latency_full_process: %s" %(self.loop_count, self.image_file_name, self.filename_list_index, self.num_repeat, self.stats_latency_full_process.n))
         self.latency_start_time = time.time()
         ws.send(image, WEBSOCKET_OPCODE_BINARY)
 
@@ -336,8 +382,7 @@ class WebSocketClient(Client):
 
     def on_open(self, ws):
         # As soon as the websocket is open, send the first image.
-        with open(self.image_file_name, "rb") as f:
-            image = f.read()
+        image = self.get_next_image()
         self.loop_count += 1
         self.latency_start_time = time.time()
         ws.send(image, WEBSOCKET_OPCODE_BINARY)
@@ -398,9 +443,8 @@ if __name__ == "__main__":
             parser.print_usage()
             sys.exit()
 
-        client.image_file_name = client.filename_list[0]
+        client.filename_list_index = -1
         client.num_repeat = args.repeat * len(client.filename_list)
-
         client.do_server_stats = args.server_stats
         client.show_responses = args.show_responses
         client.endpoint = args.endpoint

--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -75,7 +75,7 @@ class Client:
         self.stats_latency_full_process = RunningStats()
         self.stats_latency_network_only = RunningStats()
         self.stats_server_processing_time = RunningStats()
-        self.image_file_name = None
+        self.media_file_name = None
         self.latency_start_time = 0
         self.loop_count = 0
         self.num_repeat = 0
@@ -91,12 +91,12 @@ class Client:
         logger.debug("host:port = %s:%d" %(self.host, self.port))
 
     def start(self):
-        logger.debug("image file(s) %s" %(self.filename_list))
-        video_extensions = ('mp4','avi', 'mov')
+        logger.debug("media file(s) %s" %(self.filename_list))
+        video_extensions = ('mp4', 'avi', 'mov')
         if self.filename_list[0].endswith(video_extensions):
             logger.debug("It's a video")
-            self.image_file_name = self.filename_list[0]
-            self.video = cv2.VideoCapture(self.image_file_name)
+            self.media_file_name = self.filename_list[0]
+            self.video = cv2.VideoCapture(self.media_file_name)
 
     def get_next_image(self):
         if self.video is not None:
@@ -131,8 +131,8 @@ class Client:
             if self.stats_latency_full_process.n >= self.num_repeat:
                 return None
 
-            self.image_file_name = self.filename_list[self.filename_list_index]
-            with open(self.image_file_name, "rb") as f:
+            self.media_file_name = self.filename_list[self.filename_list_index]
+            with open(self.media_file_name, "rb") as f:
                 image = f.read()
 
         logger.debug("Image data (first 32 bytes logged): %s" %image[:32])
@@ -381,7 +381,7 @@ class WebSocketClient(Client):
             self.display_results()
             ws.close()
             return
-        logger.debug("loop_count: %d image_file_name: %s filename_list_index: %s num_repeat: %s count_latency_full_process: %s" %(self.loop_count, self.image_file_name, self.filename_list_index, self.num_repeat, self.stats_latency_full_process.n))
+        logger.debug("loop_count: %d media_file_name: %s filename_list_index: %s num_repeat: %s count_latency_full_process: %s" %(self.loop_count, self.media_file_name, self.filename_list_index, self.num_repeat, self.stats_latency_full_process.n))
         self.latency_start_time = time.time()
         ws.send(image, WEBSOCKET_OPCODE_BINARY)
 

--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -105,7 +105,6 @@ class Client:
                 if not ret:
                     logger.debug("End of video")
                     return None
-            self.frame_count += 1
             vw = image.shape[1]
             vh = image.shape[0]
             logger.debug("Video size: %dx%d" %(vw, vh))

--- a/FaceDetectionServer/client/multi_client.py
+++ b/FaceDetectionServer/client/multi_client.py
@@ -260,8 +260,8 @@ class RestClient(Client):
         """
         Sends the raw image data with a 'Content-Type' of 'image/jpeg'.
         """
-        # headers = {'Content-Type': 'image/jpeg'}
-        headers = {'Content-Type': 'image/jpeg', "Mobiledgex-Debug": "true"} # Enable saving debug images
+        # headers = {'Content-Type': 'image/jpeg', "Mobiledgex-Debug": "true"} # Enable saving debug images
+        headers = {'Content-Type': 'image/jpeg'}
         return requests.post(self.url, data=image, headers=headers)
 
     def send_image_json(self, image):

--- a/FaceDetectionServer/moedx/tracker/apps.py
+++ b/FaceDetectionServer/moedx/tracker/apps.py
@@ -65,8 +65,8 @@ class TrackerConfig(AppConfig):
         supportOpenPose = False
 
         # Our docker container has the openpose libraries at the root
-        # Note that the "docker run" command must include the --runtime=nvidia parameter. Example:
-        # sudo docker run --runtime=nvidia --net=host mobiledgex/openpose-docker:20200116
+        # Note that the "docker run" command must include the "--gpus all" parameter. Example:
+        # sudo docker run --gpus all --net=host mobiledgex/mobiledgexsdkdemo20:20200423
         sys.path.append('/openpose/build/python')
         try:
             from openpose import pyopenpose as myOpenPose

--- a/FaceDetectionServer/moedx/tracker/utils.py
+++ b/FaceDetectionServer/moedx/tracker/utils.py
@@ -12,9 +12,9 @@ def usage_gpu():
     """
     nvidia_smi = "nvidia-smi"
     try:
-        p = Popen([nvidia_smi,"-q", "-d", "UTILIZATION"], stdout=PIPE)
+        p = Popen([nvidia_smi, "-q", "-d", "UTILIZATION"], stdout=PIPE)
     except FileNotFoundError:
-        logger.error("%s not found. GPU usage not supported." %nvidia_smi)
+        logger.error("%s not found. Check if your Nvidia driver install is correct. GPU usage not supported." %nvidia_smi)
         return {} # Empty dict
 
     stdout, stderror = p.communicate()

--- a/FaceDetectionServer/moedx/tracker/utils.py
+++ b/FaceDetectionServer/moedx/tracker/utils.py
@@ -1,0 +1,80 @@
+import psutil
+import logging
+import os
+import json
+from subprocess import Popen, PIPE
+
+logger = logging.getLogger(__name__)
+
+def usage_gpu():
+    """
+    Execute the "nvidia-smi" command and parse the output to get the GPU usage.
+    """
+    nvidia_smi = "nvidia-smi"
+    try:
+        p = Popen([nvidia_smi,"-q", "-d", "UTILIZATION"], stdout=PIPE)
+    except FileNotFoundError:
+        logger.error("%s not found. GPU usage not supported." %nvidia_smi)
+        return {} # Empty dict
+
+    stdout, stderror = p.communicate()
+    output = stdout.decode('UTF-8')
+    # Split on line break
+    lines = output.split(os.linesep)
+    gpu_utilization_snapshot_section = False
+    gpu_utilization_samples_section = False
+    memory_utilization_samples_section = False
+    gpu_utilization_snapshot = -1
+    gpu_utilization_high = -1
+    memory_utilization_high = -1
+
+    for line in lines:
+        # print(line, gpu_utilization_snapshot_section, gpu_utilization_samples_section, memory_utilization_samples_section)
+        if line.strip() == "Utilization":
+            gpu_utilization_snapshot_section = True
+            gpu_utilization_samples_section = False
+            memory_utilization_samples_section = False
+        elif line.strip() == "GPU Utilization Samples":
+            gpu_utilization_snapshot_section = False
+            gpu_utilization_samples_section = True
+            memory_utilization_samples_section = False
+        elif line.strip() == "Memory Utilization Samples":
+            gpu_utilization_snapshot_section = False
+            gpu_utilization_samples_section = False
+            memory_utilization_samples_section = True
+        elif line.strip() == "ENC Utilization Samples":
+            # When we hit this line, we're done
+            break
+        elif line.strip().startswith("Gpu"):
+            if gpu_utilization_snapshot_section:
+                vals = line.split()
+                gpu_utilization_snapshot = vals[2]
+        elif line.strip().startswith("Max"):
+            if gpu_utilization_samples_section:
+                vals = line.split()
+                gpu_utilization_high = vals[2]
+            elif memory_utilization_samples_section:
+                vals = line.split()
+                memory_utilization_high = vals[2]
+
+    ret = {"gpu_utilization_snapshot": gpu_utilization_snapshot,
+            "gpu_utilization_high": gpu_utilization_high,
+            "gpu_memory_utilization_high": memory_utilization_high}
+    logger.info("GPU Stats: %s" %(ret))
+    return ret
+
+def usage_cpu_and_mem():
+    """
+    Return the cpu and memory usage in percent.
+    """
+    import psutil
+    cpu = psutil.cpu_percent()
+    mem = dict(psutil.virtual_memory()._asdict())['percent']
+    ret = {"cpu_utilization": cpu,
+            "mem_utilization": mem}
+    logger.info("CPU Stats: %s" %(ret))
+    return ret
+
+if __name__ == "__main__":
+    print(usage_cpu_and_mem())
+    print(usage_gpu())

--- a/FaceDetectionServer/moedx/tracker/views.py
+++ b/FaceDetectionServer/moedx/tracker/views.py
@@ -160,9 +160,7 @@ def detector_detect(request):
         ret = {"success": "true", "server_processing_time": elapsed, "rects": rects.tolist()}
     logger.info(prepend_ip("%s ms to detect rectangles: %s" %(elapsed, ret), request))
     json_ret = json.dumps(ret)
-    resp = HttpResponse(json_ret)
-    resp['Access-Control-Allow-Origin'] = '*'
-    return resp
+    return HttpResponse(json_ret)
 
 @csrf_exempt
 def recognizer_update(request):


### PR DESCRIPTION
- multi_client.py can use video for testing. 
- Frames are resized to the same dimensions as the Android demo app, unless overridden with --fullsize flag.
- --skip-frames parameter to send every Nth frame, for faster tests.
- Get weights file from faster server. Original location was a 10 minute DL every time you do a docker build.
- Moved CPU/GPU usage functions to utils.py so they they can be imported by other classes.
