### PR TITLE
EDGECLOUD-2818 Docker multistage builds for smaller images

### DIFF
--- a/FaceDetectionServer/Dockerfile
+++ b/FaceDetectionServer/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim AS compile-image
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 # Use a virtualenv for all of our Python requirements.
 RUN python -m venv /opt/venv
 # Make sure we use the virtualenv:

--- a/FaceDetectionServer/Dockerfile
+++ b/FaceDetectionServer/Dockerfile
@@ -1,11 +1,25 @@
-FROM python:3.6.6-onbuild
-COPY requirements.txt /tmp
-WORKDIR /tmp
+FROM python:3.7-slim AS compile-image
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc
+# Use a virtualenv for all of our Python requirements.
+RUN python -m venv /opt/venv
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip3 install wheel
+# Dependencies for our Django app.
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+FROM python:3.7-slim AS build-image
+COPY --from=compile-image /opt/venv /opt/venv
+RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender1 libxext6 wget
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
+
 # Download weights file required for object detection
 WORKDIR /usr/src/app/moedx/pytorch_objectdetecttrack/config
 RUN wget http://opencv.facetraining.mobiledgex.net/files/yolov3.weights
 WORKDIR /usr/src/app/moedx
+COPY . /usr/src/app
 # Initialize the database.
 RUN python manage.py makemigrations tracker
 RUN python manage.py migrate
@@ -13,7 +27,6 @@ RUN python manage.py migrate
 EXPOSE 8008/tcp
 # port for persistent TCP server
 EXPOSE 8011/tcp
-ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Fix for "click" Python library, a uvicorn dependency.
 ENV LC_ALL=C.UTF-8

--- a/FaceDetectionServer/Dockerfile_openpose
+++ b/FaceDetectionServer/Dockerfile_openpose
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:10.0-cudnn7-devel
+FROM nvidia/cuda:10.0-cudnn7-devel AS compile-image
 
 #get deps
 RUN apt-get update && \
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-python3-dev python3-pip git g++ wget make libprotobuf-dev protobuf-compiler libopencv-dev \
+python3.7-dev python3-pip git g++ wget make libprotobuf-dev protobuf-compiler libopencv-dev \
 libgoogle-glog-dev libboost-all-dev libcaffe-cuda-dev libhdf5-dev libatlas-base-dev
 
 #replace cmake as old version has CUDA variable bugs
@@ -18,28 +18,50 @@ RUN git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose.git .
 
 #build it
 WORKDIR /openpose/build
+#patch because dataset server posefs1.perception.cs.cmu.edu is unavailable (2020-05-15)
+RUN sed 's/posefs1.perception.cs.cmu.edu/opencv.facetraining.mobiledgex.net/g' /openpose/models/getModels.sh
 RUN cmake -DBUILD_PYTHON=ON .. && make -j `nproc`
-WORKDIR /openpose
 
-# Dependencies for our Django app.
+# Use a virtualenv for all of our Python requirements.
+RUN apt-get install -y python3.7-venv
+# Giant list of dependencies for imagecodecs package. See https://pypi.org/project/imagecodecs/
+RUN apt-get install -y python3-blosc python3-brotli python3-snappy python3-lz4 libz-dev libblosc-dev \
+liblzma-dev liblz4-dev libzstd-dev libpng-dev libwebp-dev libbz2-dev libopenjp2-7-dev libjpeg-turbo8-dev \
+libjxr-dev liblcms2-dev libcharls-dev libaec-dev libbrotli-dev libsnappy-dev libzopfli-dev libgif-dev libtiff-dev
+
+# Not sure why it can't find these headers. Copy them where they can be found.
+RUN cp /usr/include/openjpeg-2.3/*.h /usr/include/
+RUN python3.7 -m venv /opt/venv
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install wheel
-RUN apt-get install python3-setuptools -y
-COPY requirements.txt /tmp
-WORKDIR /tmp
-RUN pip3 install -r requirements.txt
+# Dependencies for our Django app.
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+FROM nvidia/cuda:10.0-cudnn7-runtime AS build-image
+COPY --from=compile-image /openpose /openpose
+COPY --from=compile-image /opt/venv /opt/venv
+RUN apt-get update && \
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+python3.7-dev python3-pip git g++ wget make libopencv-dev \
+libgoogle-glog-dev libboost-all-dev libcaffe-cuda-dev libhdf5-dev libatlas-base-dev
+
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
+
 # Download weights file required for object detection
 WORKDIR /usr/src/app/moedx/pytorch_objectdetecttrack/config
 RUN wget http://opencv.facetraining.mobiledgex.net/files/yolov3.weights
 WORKDIR /usr/src/app/moedx
 COPY . /usr/src/app
 # Initialize the database.
-RUN python3 manage.py makemigrations tracker
-RUN python3 manage.py migrate
+RUN python manage.py makemigrations tracker
+RUN python manage.py migrate
 # port for REST
 EXPOSE 8008/tcp
 # port for persistent TCP server
 EXPOSE 8011/tcp
-ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Fix for "click" Python library, a uvicorn dependency.
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
An update to one of the Python dependencies caused the docker build to break. Changing the base image from python:3.6.6-onbuild to python:3.7.5 fixed the problem, but made the image file 4.23GB, up from 2.98GB. Using a multistage build to drop all of the stuff required for building from source resulted in a final image size of 2.61GB.

The GPU side was quite a bit trickier. I used the same basic technique: A first image that had everything needed to build libraries, including OpenPose, from source, and a second image that only included what is needed at runtime. I was not able to drop as many -dev libraries as I hoped, but I did get the final size down from 8.71GB to 6.3GB. Still way bigger that I would like, but the CUDA/CUDNN base is massive, OpenPose is huge, and the PyTorch stuff is large. There's no way I can see to shrink it down farther.