### PR TITLE
EDGECLOUD-2855 EDGECLOUD-2974 EDGECLOUD-3064 HA and more

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,7 +9,7 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 28
-        versionCode 56
+        versionCode 57
         versionName "1.1.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 56
-        versionName "1.1.7"
+        versionName "1.1.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/release/output.json
+++ b/android/MobiledgeXSDKDemo/app/release/output.json
@@ -1,1 +1,20 @@
-[{"outputType":{"type":"APK"},"apkData":{"type":"MAIN","splits":[],"versionCode":55,"versionName":"1.1.6","enabled":true,"outputFile":"MobiledgeXSDKDemo-release.apk","fullName":"release","baseName":"release","dirName":""},"path":"MobiledgeXSDKDemo-release.apk","properties":{}}]
+{
+  "version": 1,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "com.mobiledgex.sdkdemo",
+  "variantName": "release",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "properties": [],
+      "versionCode": 56,
+      "versionName": "56",
+      "enabled": true,
+      "outputFile": "MobiledgeXSDKDemo-release.apk"
+    }
+  ]
+}

--- a/android/MobiledgeXSDKDemo/app/src/main/assets/about_dialog.html
+++ b/android/MobiledgeXSDKDemo/app/src/main/assets/about_dialog.html
@@ -1,23 +1,31 @@
-<p>Version: ${appVersion}</p>
+<p>Version: ${androidAppVersion}</p>
 <p>This app uses the MobiledgeX Matching Engine SDK to find and display on a map all of the
-Cloudlets running the backend app that provides the speed test and computer vision services
-needed by this app. It uses the following information for the SDK API calls:</p>
+ Cloudlets running the backend app that provides the speed test and computer vision services
+ needed by this app. It uses the following information for the SDK API calls:</p>
 <table border="2">
     <tbody>
     <tr>
         <td><strong>appName</strong></td>
-        <td>MobiledgeX SDK Demo</td>
+        <td>${appName}</td>
     </tr>
     <tr>
-        <td><strong>devName</strong></td>
-        <td>MobiledgeX</td>
+        <td><strong>orgName</strong></td>
+        <td>${orgName}</td>
     </tr>
     <tr>
         <td><strong>appVer</strong></td>
-        <td>2.0</td>
+        <td>${appVersion}</td>
+    </tr>
+    <tr>
+        <td><strong>Operator</strong></td>
+        <td>${operator}</td>
+    </tr>
+    <tr>
+        <td><strong>Region</strong></td>
+        <td>${region}</td>
     </tr>
     </tbody>
 </table>
-<p>The Operator name and Region selection values can be changed in the General Settings of the app.</p>
+<p>These values can be changed in the General Settings of the app.</p>
 <p>To learn more about the MobiledgeX SDK, see <a href="https://developers.mobiledgex.com/">developers.mobiledgex.com</a> for documentation and a Getting Started guide.</p>
 <p>Source code for this app is available on <a href="https://github.com/mobiledgex/edge-cloud-sampleapps/tree/master/android/MobiledgeXSDKDemo">Github</a>.</p>

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -44,7 +44,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import android.preference.PreferenceScreen;
 import android.util.ArrayMap;
 import android.util.Log;
 import android.view.Menu;
@@ -91,6 +90,7 @@ import com.mobiledgex.computervision.ImageSender;
 import com.mobiledgex.computervision.ObjectProcessorActivity;
 import com.mobiledgex.computervision.PoseProcessorActivity;
 import com.mobiledgex.computervision.PoseProcessorFragment;
+import com.mobiledgex.matchingengine.DmeDnsException;
 import com.mobiledgex.matchingengine.MatchingEngine;
 import com.mobiledgex.matchingengine.util.RequestPermissions;
 import com.mobiledgex.sdkdemo.qoe.QoeMapActivity;
@@ -105,10 +105,10 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -139,12 +139,17 @@ public class MainActivity extends AppCompatActivity
 
     private static final int RC_SIGN_IN = 1;
     public static final int RC_STATS = 2;
-    public static final String DEFAULT_DME_HOSTNAME = "eu-mexdemo.dme.mobiledgex.net";
-    public static final String DEFAULT_CARRIER_NAME = "TDG";
+    public static final String DEFAULT_DME_HOSTNAME = "wifi.dme.mobiledgex.net";
+    public static final String DEFAULT_CARRIER_NAME = "";
+    public static final String DEFAULT_FIND_CLOUDLET_MODE = "PROXIMITY";
     private String mDefaultCarrierName;
     private String mDefaultDmeHostname;
-    private String mHostname;
-    private String mCarrierName;
+    protected static String mHostname;
+    protected static String mCarrierName;
+    protected static String mRegionName;
+    protected static String mAppName;
+    protected static String mAppVersion;
+    protected static String mOrgName;
     private boolean mNetworkSwitchingAllowed;
 
     private GoogleMap mGoogleMap;
@@ -173,6 +178,8 @@ public class MainActivity extends AppCompatActivity
     private MenuItem signOutMenuItem;
     private AlertDialog mAlertDialog;
     private boolean mAllowLocationSimulatorUpdate = false;
+    private boolean uiHasBeenTouched;
+    private MatchingEngine.FindCloudletMode mFindCloudletMode;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -276,18 +283,22 @@ public class MainActivity extends AppCompatActivity
         }
 
         // Reuse the onSharedPreferenceChanged code to initialize anything dependent on these prefs:
-//        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_dme_hostname));
-//        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_operator_name));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_default_dme_hostname));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_default_operator_name));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_find_cloudlet_mode));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.download_size));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.upload_size));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.latency_packets));
-        onSharedPreferenceChanged(prefs, getResources().getString(R.string.latency_method));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_latency_method));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_latency_autostart));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_default_app_definition));
 
         // Watch for any updated preferences:
         prefs.registerOnSharedPreferenceChangeListener(this);
+
+        // TODO: If TDG ever restores their PQoE backend, unhide this menu item
+        MenuItem qoeMenuItem = navigationView.getMenu().findItem(R.id.nav_qoe_map);
+        qoeMenuItem.setVisible(false);
     }
 
     /**
@@ -311,7 +322,7 @@ public class MainActivity extends AppCompatActivity
         Log.i(TAG, "matchingEngineRequest("+reqType+") mLastKnownLocation="+mLastKnownLocation);
         if(mLastKnownLocation == null) {
             startLocationUpdates();
-            Toast.makeText(MainActivity.this, "Waiting for GPS signal. Please retry in a moment.", Toast.LENGTH_LONG).show();
+            showGpsWarning();
             return;
         }
         mMatchingEngineHelper.doRequestInBackground(reqType, mLocationForMatching);
@@ -344,7 +355,13 @@ public class MainActivity extends AppCompatActivity
                 sb.append(str);
             }
             String htmlData = sb.toString();
-            htmlData = htmlData.replace("${appVersion}", appVersion);
+            htmlData = htmlData.replace("${androidAppVersion}", appVersion)
+                    .replace("${appName}", mAppName)
+                    .replace("${appVersion}", mAppVersion)
+                    .replace("${orgName}", mOrgName)
+                    .replace("${operator}", mCarrierName)
+                    .replace("${region}", mHostname)
+                    .replace(".dme.mobiledgex.net", "");
 
             // The WebView to show our HTML.
             WebView webView = new WebView(MainActivity.this);
@@ -383,6 +400,7 @@ public class MainActivity extends AppCompatActivity
         // Handle action bar item clicks here. The action bar will
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
+        uiHasBeenTouched = true;
         int id = item.getItemId();
 
         if (id == R.id.action_register_client) {
@@ -395,7 +413,7 @@ public class MainActivity extends AppCompatActivity
             // Reset spoofed GPS
             if(mLastKnownLocation == null) {
                 startLocationUpdates();
-                Toast.makeText(MainActivity.this, "Waiting for GPS signal. Please retry in a moment.", Toast.LENGTH_LONG).show();
+                showGpsWarning();
                 return true;
             }
             if(mUserLocationMarker == null) {
@@ -427,6 +445,7 @@ public class MainActivity extends AppCompatActivity
     @Override
     public boolean onNavigationItemSelected(MenuItem item) {
         // Handle navigation view item clicks here.
+        uiHasBeenTouched = true;
         int id = item.getItemId();
 
         if (id == R.id.nav_settings) {
@@ -442,6 +461,7 @@ public class MainActivity extends AppCompatActivity
             // Start the face detection Activity
             Intent intent = new Intent(this, ImageProcessorActivity.class);
             intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname);
+            putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
         } else if (id == R.id.nav_face_recognition) {
@@ -449,6 +469,7 @@ public class MainActivity extends AppCompatActivity
             Intent intent = new Intent(this, ImageProcessorActivity.class);
             intent.putExtra(ImageProcessorFragment.EXTRA_FACE_RECOGNITION, true);
             intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname);
+            putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
         } else if (id == R.id.nav_pose_detection) {
@@ -457,14 +478,16 @@ public class MainActivity extends AppCompatActivity
             //Due to limited GPU availabilty, we don't want to override the default yet.
             //It's still possible to override the default via preferences.
             //TODO: Add this back when we have more cloudlets with GPU support.
-//            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname);
+//            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname1);
+            putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
         } else if (id == R.id.nav_object_detection) {
             // Start the object detection Activity
             Intent intent = new Intent(this, ObjectProcessorActivity.class);
             //TODO: Add this back when we have more cloudlets with GPU support.
-//            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname);
+//            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, mClosestCloudletHostname1);
+            putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
         } else if (id == R.id.nav_qoe_map) {
@@ -500,6 +523,27 @@ public class MainActivity extends AppCompatActivity
         DrawerLayout drawer = findViewById(R.id.drawer_layout);
         drawer.closeDrawer(GravityCompat.START);
         return true;
+    }
+
+    public void putCommonIntentExtras(Intent intent) {
+        intent.putExtra(ImageProcessorFragment.EXTRA_APP_NAME, mAppName);
+        intent.putExtra(ImageProcessorFragment.EXTRA_APP_VERSION, mAppVersion);
+        intent.putExtra(ImageProcessorFragment.EXTRA_ORG_NAME, mOrgName);
+        intent.putExtra(ImageProcessorFragment.EXTRA_FIND_CLOUDLET_MODE, mFindCloudletMode.name());
+        intent.putExtra(ImageProcessorFragment.EXTRA_DME_HOSTNAME, mHostname);
+        intent.putExtra(ImageProcessorFragment.EXTRA_CARRIER_NAME, mCarrierName);
+        Log.i(TAG, "mLastKnownLocation="+mLastKnownLocation);
+        Location cvLocation;
+        if(mMatchingEngineHelper.getSpoofedLocation() == null) {
+            cvLocation = mLastKnownLocation;
+        } else {
+            cvLocation = mMatchingEngineHelper.getSpoofedLocation();
+        }
+        if (cvLocation != null) {
+            Log.i(TAG, "cvLocation="+cvLocation);
+            intent.putExtra(ImageProcessorFragment.EXTRA_LATITUDE, cvLocation.getLatitude());
+            intent.putExtra(ImageProcessorFragment.EXTRA_LONGITUDE, cvLocation.getLongitude());
+        }
     }
 
     @Override
@@ -627,10 +671,14 @@ public class MainActivity extends AppCompatActivity
      *
      */
     public void getCloudlets() {
-        Log.i(TAG, "getCloudletList() mLastKnownLocation="+mLastKnownLocation);
+        Log.i(TAG, "getCloudlets() mLastKnownLocation="+mLastKnownLocation+" mMatchingEngineHelper="+mMatchingEngineHelper);
+        if (mMatchingEngineHelper == null) {
+            Log.i(TAG, "getCloudlets() mMatchingEngineHelper not yet initialized");
+            return;
+        }
         if(mLastKnownLocation == null) {
             startLocationUpdates();
-            Toast.makeText(MainActivity.this, "Waiting for GPS signal. Please retry in a moment.", Toast.LENGTH_LONG).show();
+            showGpsWarning();
             return;
         }
 
@@ -641,6 +689,12 @@ public class MainActivity extends AppCompatActivity
         }
 
         mMatchingEngineHelper.doRequestInBackground(REQ_GET_CLOUDLETS, mLocationForMatching);
+    }
+
+    public void showGpsWarning() {
+        if (uiHasBeenTouched) {
+            Toast.makeText(MainActivity.this, "Waiting for GPS signal. Please retry in a moment.", Toast.LENGTH_SHORT).show();
+        }
     }
 
     @NonNull
@@ -872,7 +926,7 @@ public class MainActivity extends AppCompatActivity
                             .color(COLOR_VERIFIED));
                     //Save the hostname for use by Face Detection Activity.
                     mClosestCloudletHostname = cloudlet.getHostName();
-                    Log.i(TAG, "mClosestCloudletHostname: "+mClosestCloudletHostname);
+                    Log.i(TAG, "mClosestCloudletHostname1: "+ mClosestCloudletHostname);
                 }
             }
         });
@@ -920,7 +974,7 @@ public class MainActivity extends AppCompatActivity
                     String cloudletName = cloudletLocation.getCloudletName();
                     List<AppClient.Appinstance> appInstances = cloudletLocation.getAppinstancesList();
                     //TODO: What if there is more than 1 appInstance in the list?
-                    //There shouldn't be since we use all of appName, appVer, and devName in the
+                    //There shouldn't be since we use all of appName, appVer, and orgName in the
                     //request. There should only be a single match.
                     String uri = appInstances.get(0).getFqdn();
                     String appName = appInstances.get(0).getAppName();
@@ -957,7 +1011,6 @@ public class MainActivity extends AppCompatActivity
                     cloudlet.update(cloudletName, appName, carrierName, latLng, distance, uri, marker, FQDNPrefix, publicPort);
                     tempCloudlets.put(cloudletName, cloudlet);
                     builder.include(marker.getPosition());
-
                 }
 
                 //Now see if all cloudlets still exist. If removed, show as transparent.
@@ -1140,23 +1193,29 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+    public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, String key) {
         Log.d(TAG, "onSharedPreferenceChanged("+key+")");
+        boolean appInfoChanged = false;
         String prefKeyAllowMatchingEngineLocation = getResources().getString(R.string.preference_matching_engine_location_verification);
         String prefKeyAllowNetSwitch = getResources().getString(R.string.preference_net_switching_allowed);
         String prefKeyDownloadSize = getResources().getString(R.string.download_size);
         String prefKeyUploadSize = getResources().getString(R.string.upload_size);
         String prefKeyNumPackets = getResources().getString(R.string.latency_packets);
-        String prefKeyLatencyMethod = getResources().getString(R.string.latency_method);
+        String prefKeyLatencyMethod = getResources().getString(R.string.pref_latency_method);
         String prefKeyLatencyAutoStart = getResources().getString(R.string.pref_latency_autostart);
         String prefKeyDmeHostname = getResources().getString(R.string.pref_dme_hostname);
         String prefKeyOperatorName = getResources().getString(R.string.pref_operator_name);
         String prefKeyDefaultDmeHostname = getResources().getString(R.string.pref_default_dme_hostname);
         String prefKeyDefaultOperatorName = getResources().getString(R.string.pref_default_operator_name);
+        String prefKeyFindCloudletMode = getResources().getString(R.string.pref_find_cloudlet_mode);
         String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
         String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
         String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
         String prefKeyResetFdHosts = getResources().getString(R.string.preference_fd_reset_both_hosts);
+        String prefKeyDefaultAppInfo = getResources().getString(R.string.pref_default_app_definition);
+        String prefKeyAppName = getResources().getString(R.string.pref_app_name);
+        String prefKeyAppVersion = getResources().getString(R.string.pref_app_version);
+        String prefKeyOrgName = getResources().getString(R.string.pref_org_name);
 
         if (key.equals(prefKeyAllowMatchingEngineLocation)) {
             boolean matchingEngineLocationAllowed = sharedPreferences.getBoolean(prefKeyAllowMatchingEngineLocation, false);
@@ -1184,21 +1243,29 @@ public class MainActivity extends AppCompatActivity
             CloudletListHolder.getSingleton().setLatencyTestAutoStart(latencyTestAutoStart);
         }
 
-        if (key.equals(prefKeyDefaultDmeHostname) || key.equals(prefKeyDefaultOperatorName)) {
-            // Temporary instance just to get these values.
-            MatchingEngine me = new MatchingEngine(this);
-            mDefaultCarrierName = me.getCarrierName(this);
-            mDefaultDmeHostname = new StringBuilder(mDefaultCarrierName)
-                    .insert(3, "-").append(".dme.mobiledgex.net").toString();
-            Log.i(TAG, "mDefaultCarrierName="+mDefaultCarrierName+" mDefaultDmeHostname="+mDefaultDmeHostname);
-        }
-
         if (key.equals(prefKeyDefaultDmeHostname)) {
             boolean useDefault = sharedPreferences.getBoolean(prefKeyDefaultDmeHostname, true);
             if (useDefault) {
-                String prefKeyValueDefaultDmeHostname = getResources().getString(R.string.pref_value_default_dme_hostname);
-                sharedPreferences.edit().putString(prefKeyValueDefaultDmeHostname, mDefaultDmeHostname).apply();
-                setDmeHostname(mDefaultDmeHostname);
+                if (mMatchingEngineHelper != null) {
+                    new Thread(new Runnable() {
+                        @Override public void run() {
+                            try {
+                                mDefaultDmeHostname = mMatchingEngineHelper.getMatchingEngine().generateDmeHostAddress();
+                                String prefKeyValueDefaultDmeHostname = getResources().getString(R.string.pref_value_default_dme_hostname);
+                                sharedPreferences.edit().putString(prefKeyValueDefaultDmeHostname, mDefaultDmeHostname).apply();
+                                setDmeHostname(mDefaultDmeHostname);
+                            } catch (DmeDnsException e) {
+                                mDefaultDmeHostname = DEFAULT_DME_HOSTNAME;
+                                mMatchingEngineHelper.getMatchingEngine().setUseWifiOnly(true);
+                            }
+                            Log.i(TAG, "mDefaultCarrierName="+mDefaultCarrierName+" mDefaultDmeHostname="+mDefaultDmeHostname);
+                        }
+                    }).start();
+
+                } else {
+                    Log.i(TAG, "MatchingEngine not yet available. Skipping "+key);
+                    return;
+                }
             } else {
                 // Change the key name so the normal DME hostname handling code will be used below.
                 key = prefKeyDmeHostname;
@@ -1208,9 +1275,16 @@ public class MainActivity extends AppCompatActivity
         if (key.equals(prefKeyDefaultOperatorName)) {
             boolean useDefault = sharedPreferences.getBoolean(prefKeyDefaultOperatorName, true);
             if (useDefault) {
-                String prefKeyValueDefaultOperatorName = getResources().getString(R.string.pref_value_default_operator_name);
-                sharedPreferences.edit().putString(prefKeyValueDefaultOperatorName, mDefaultCarrierName).apply();
-                setCarrierName(mDefaultCarrierName);
+                if (mMatchingEngineHelper != null) {
+                    mDefaultCarrierName = mMatchingEngineHelper.getMatchingEngine().getCarrierName(this);
+                    Log.i(TAG, "mDefaultCarrierName=" + mDefaultCarrierName);
+                    String prefKeyValueDefaultOperatorName = getResources().getString(R.string.pref_value_default_operator_name);
+                    sharedPreferences.edit().putString(prefKeyValueDefaultOperatorName, mDefaultCarrierName).apply();
+                    setCarrierName(mDefaultCarrierName);
+                } else {
+                    Log.i(TAG, "MatchingEngine not yet available. Skipping "+key);
+                    return;
+                }
             } else {
                 // Change the key name so the normal Operator name handling code will be used below.
                 key = prefKeyOperatorName;
@@ -1239,6 +1313,43 @@ public class MainActivity extends AppCompatActivity
             String carrierName = sharedPreferences.getString(prefKeyOperatorName, DEFAULT_CARRIER_NAME);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+carrierName);
             setCarrierName(carrierName);
+        }
+
+        if (key.equals(prefKeyFindCloudletMode)) {
+            String findCloudletMode = sharedPreferences.getString(prefKeyFindCloudletMode, DEFAULT_FIND_CLOUDLET_MODE);
+            mFindCloudletMode = MatchingEngine.FindCloudletMode.valueOf(findCloudletMode);
+            Log.i(TAG, "findCloudletMode="+findCloudletMode+" mFindCloudletMode="+mFindCloudletMode);
+        }
+
+        if (key.equals(prefKeyDefaultAppInfo)) {
+            boolean useDefault = sharedPreferences.getBoolean(prefKeyDefaultAppInfo, true);
+            if (useDefault) {
+                mAppName = getResources().getString(R.string.app_name);
+                mAppVersion = getResources().getString(R.string.app_version);
+                mOrgName = getResources().getString(R.string.org_name);
+            } else {
+                mAppName = sharedPreferences.getString(prefKeyAppName, getResources().getString(R.string.app_name));
+                mAppVersion = sharedPreferences.getString(prefKeyAppVersion, getResources().getString(R.string.app_version));
+                mOrgName = sharedPreferences.getString(prefKeyOrgName, getResources().getString(R.string.org_name));
+                Log.i(TAG, "onSharedPreferenceChanged("+key+")=false. Custom values: appName="+mAppName+" appVersion="+mAppVersion+" orgName="+mOrgName);
+            }
+            appInfoChanged = true;
+        }
+
+        if (key.equals(prefKeyAppName)) {
+            mAppName = sharedPreferences.getString(key, getResources().getString(R.string.app_name));
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mAppName);
+            appInfoChanged = true;
+        }
+        if (key.equals(prefKeyAppVersion)) {
+            mAppVersion = sharedPreferences.getString(key, getResources().getString(R.string.app_version));
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mAppVersion);
+            appInfoChanged = true;
+        }
+        if (key.equals(prefKeyOrgName)) {
+            mOrgName = sharedPreferences.getString(key, getResources().getString(R.string.org_name));
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mAppName);
+            appInfoChanged = true;
         }
 
         if (key.equals(prefKeyDownloadSize)) {
@@ -1288,28 +1399,28 @@ public class MainActivity extends AppCompatActivity
             //will activate this "changed" call.
             sharedPreferences.edit().putString(prefKeyResetFdHosts, "XXX_garbage_value").apply();
         }
+
+        if (appInfoChanged) {
+            //Clear list so we don't show old cloudlets as transparent
+            CloudletListHolder.getSingleton().getCloudletList().clear();
+            getCloudlets();
+        }
     }
 
     public void setCarrierName(String carrierName) {
         mCarrierName = carrierName;
         mClosestCloudletHostname = null;
-        if(mMatchingEngineHelper != null) {
-            mMatchingEngineHelper.setCarrierName(carrierName);
-            //Clear list so we don't show old cloudlets as transparent
-            CloudletListHolder.getSingleton().getCloudletList().clear();
-            getCloudlets();
-        }
+        //Clear list so we don't show old cloudlets as transparent
+        CloudletListHolder.getSingleton().getCloudletList().clear();
+        getCloudlets();
     }
 
     public void setDmeHostname(String hostname) {
         mHostname = hostname;
         mClosestCloudletHostname = null;
-        if(mMatchingEngineHelper != null) {
-            mMatchingEngineHelper.setHostname(mHostname);
-            //Clear list so we don't show old cloudlets as transparent
-            CloudletListHolder.getSingleton().getCloudletList().clear();
-            getCloudlets();
-        }
+        //Clear list so we don't show old cloudlets as transparent
+        CloudletListHolder.getSingleton().getCloudletList().clear();
+        getCloudlets();
         checkForLocSimulator(mHostname);
     }
 
@@ -1388,9 +1499,14 @@ public class MainActivity extends AppCompatActivity
     public void initMatchingEngineHelper() {
         Log.i(TAG, "initMatchingEngineHelper()");
         Log.i(TAG, "mHostname="+mHostname+" networkSwitchingAllowed="+mNetworkSwitchingAllowed+" mCarrierName="+mCarrierName);
-        mMatchingEngineHelper = new MatchingEngineHelper(this, mHostname, mCarrierName , mMapFragment.getView());
+        mMatchingEngineHelper = new MatchingEngineHelper(this, mMapFragment.getView());
         mMatchingEngineHelper.setMatchingEngineResultsListener(this);
         mMatchingEngineHelper.getMatchingEngine().setNetworkSwitchingEnabled(mNetworkSwitchingAllowed);
+
+        // Initialize default dme hostname and operator.
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_default_dme_hostname));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_default_operator_name));
     }
 
     @Override

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
@@ -192,7 +192,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-            addPreferencesFromResource(R.xml.location_preferences);
+            addPreferencesFromResource(R.xml.pref_matching_engine);
             setHasOptionsMenu(true);
         }
 
@@ -233,6 +233,10 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         String prefKeyOperatorName;
         String prefKeyDefaultDmeHostname;
         String prefKeyDefaultOperatorName;
+        String prefKeyDefaultAppInfo;
+        String prefKeyAppName;
+        String prefKeyAppVersion;
+        String prefKeyOrgName;
 
         @Override
         public void onCreate(Bundle savedInstanceState) {
@@ -245,14 +249,23 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             prefKeyDefaultDmeHostname = getResources().getString(R.string.pref_default_dme_hostname);
             prefKeyOperatorName = getResources().getString(R.string.pref_operator_name);
             prefKeyDmeHostname = getResources().getString(R.string.pref_dme_hostname);
+            prefKeyDefaultAppInfo = getResources().getString(R.string.pref_default_app_definition);
+            prefKeyAppName = getResources().getString(R.string.pref_app_name);
+            prefKeyAppVersion = getResources().getString(R.string.pref_app_version);
+            prefKeyOrgName = getResources().getString(R.string.pref_org_name);
 
             // Initialize summary values for these keys.
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             onSharedPreferenceChanged(prefs, prefKeyDefaultOperatorName);
             onSharedPreferenceChanged(prefs, prefKeyDefaultDmeHostname);
             onSharedPreferenceChanged(prefs, prefKeyOperatorName);
+            onSharedPreferenceChanged(prefs, prefKeyDefaultAppInfo);
             // prefKeyDmeHostname does not need initialized here, because it is initialized with
             // the results of the dme-list.html call below.
+
+            bindPreferenceSummaryToValue(findPreference(prefKeyAppName));
+            bindPreferenceSummaryToValue(findPreference(prefKeyAppVersion));
+            bindPreferenceSummaryToValue(findPreference(prefKeyOrgName));
 
             // Instantiate the RequestQueue.
             RequestQueue queue = Volley.newRequestQueue(getActivity());
@@ -344,6 +357,9 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 String summary = getResources().getString(R.string.pref_summary_default_operator_name);
                 String prefKeyValueDefaultOperatorName = getResources().getString(R.string.pref_value_default_operator_name);
                 String operatorName = sharedPreferences.getString(prefKeyValueDefaultOperatorName, DEFAULT_CARRIER_NAME);
+                if (operatorName.isEmpty()) {
+                    operatorName = "<blank>";
+                }
                 summary = summary + ": " + operatorName;
                 pref.setSummary(summary);
             }
@@ -357,6 +373,17 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 String summary = getResources().getString(R.string.pref_summary_operator_name);
                 pref.setSummary(summary + ": " + ((EditTextPreference)pref).getText());
             }
+
+            if (key.equals(prefKeyDefaultAppInfo)) {
+                String summary = getResources().getString(R.string.pref_summary_default_app_definition);
+                String appName = getResources().getString(R.string.app_name);
+                String appVersion = getResources().getString(R.string.app_version);
+                String orgName = getResources().getString(R.string.org_name);
+                summary = summary + "\n    Name=" + appName + "\n    Version=" + appVersion + "\n    Org=" + orgName;
+                pref.setSummary(summary);
+            }
+
+
         }
     }
 
@@ -381,6 +408,14 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             setHasOptionsMenu(true);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             prefs.registerOnSharedPreferenceChangeListener(this);
+
+            String prefKeyHostCloud = getResources().getString(com.mobiledgex.computervision.R.string.preference_fd_host_cloud);
+            String prefKeyHostEdge = getResources().getString(com.mobiledgex.computervision.R.string.preference_fd_host_edge);
+            String prefKeyOpenPoseHostEdge = getResources().getString(com.mobiledgex.computervision.R.string.preference_openpose_host_edge);
+
+            bindPreferenceSummaryToValue(findPreference(prefKeyHostCloud));
+            bindPreferenceSummaryToValue(findPreference(prefKeyHostEdge));
+            bindPreferenceSummaryToValue(findPreference(prefKeyOpenPoseHostEdge));
         }
 
         @Override

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
@@ -155,7 +155,7 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
         }
 
         View mapView = findViewById(R.id.map);
-        mMatchingEngineHelper = new MatchingEngineHelper(this, mHostname, carrierName, mapView);
+        mMatchingEngineHelper = new MatchingEngineHelper(this, mapView);
         mMatchingEngineHelper.registerClientInBackground();
 
         // Build Legend Table View programmatically, based on colors and speed description values.

--- a/android/MobiledgeXSDKDemo/app/src/main/res/menu/activity_main_drawer.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/menu/activity_main_drawer.xml
@@ -11,13 +11,13 @@
             android:icon="@drawable/googleg_color"
             android:title="@string/menu_sign_out" />
         <item
-            android:id="@+id/nav_face_recognition"
-            android:icon="@drawable/ic_menu_camera"
-            android:title="@string/title_activity_face_recognition" />
-        <item
             android:id="@+id/nav_face_detection"
             android:icon="@drawable/ic_menu_camera"
             android:title="@string/title_activity_face_detection" />
+        <item
+            android:id="@+id/nav_face_recognition"
+            android:icon="@drawable/ic_menu_camera"
+            android:title="@string/title_activity_face_recognition" />
         <item
             android:id="@+id/nav_object_detection"
             android:icon="@drawable/ic_menu_camera"

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">MobiledgeX SDK Demo</string>
+    <string name="app_version">2.0</string>
+    <string name="org_name">MobiledgeX</string>
 
     <string name="yes">Yes</string>
     <string name="no">No</string>
@@ -17,7 +19,7 @@
     <string name="enhanced_location_permission">This application uses enhanced features of carrier networks to validate your device location. Please enable in app settings.</string>
     <string name="preference_matching_engine_location_verification">location_verification</string>
     <string name="preference_matching_engine_location_verification_title">Location Verification</string>
-    <string name="preference_matching_engine_location_verification_summary">Enhanced Network Location Services</string>
+    <string name="preference_matching_engine_location_verification_summary">Matching Engine Settings</string>
     <string name="preference_net_switching_allowed">net_switching_allowed</string>
     <string name="preference_net_switching_allowed_title">Network Switching Enabled</string>
     <string name="preference_net_switching_allowed_summary">Wifi to Cell network switching</string>
@@ -107,9 +109,32 @@
         <item>socket</item>
     </string-array>
 
+    <string name="pref_find_cloudlet_mode">find_cloudlet_mode</string>
+    <string name="pref_find_cloudlet_title">FindCloudlet Mode</string>
+    <string name="pref_find_cloudlet_summary">%s</string>
+    <string-array name="pref_find_cloudlet_method_titles">
+        <item>Proximity</item>
+        <item>Performance</item>
+    </string-array>
+    <string-array name="pref_find_cloudlet_method_values">
+        <item>PROXIMITY</item>
+        <item>PERFORMANCE</item>
+    </string-array>
+
     <string name="pref_latency_autostart">latency_autostart</string>
     <string name="pref_latency_autostart_title">Latency Test Auto-Start</string>
     <string name="pref_latency_autostart_summary">Automatically start latency test when cloudlet is discovered.</string>
+
+    <string name="pref_default_app_definition">pref_default_app_definition</string>
+    <string name="pref_value_default_app_definition">pref_value_default_app_definition</string>
+    <string name="pref_title_default_app_definition">Use Default App Definition</string>
+    <string name="pref_summary_default_app_definition">These values may be overridden to show a different set of app instances.</string>
+    <string name="pref_app_name">pref_app_name</string>
+    <string name="pref_title_app_name">App Name</string>
+    <string name="pref_app_version">pref_app_version</string>
+    <string name="pref_title_app_version">App Version</string>
+    <string name="pref_org_name">pref_org_name</string>
+    <string name="pref_title_org_name">Organization Name</string>
 
     <string name="pref_operator_name">pref_operator</string>
     <string name="pref_title_operator_name">Operator</string>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_general.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_general.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:id="@+id/matching_engine_general_preference_screen">
+    android:id="@+id/general_preference_screen">
 
     <CheckBoxPreference
         android:defaultValue="true"
@@ -38,5 +38,36 @@
         android:singleLine="true"
         android:summary="@string/pref_summary_operator_name"
         android:title="@string/pref_title_operator_name" />
+
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:disableDependentsState="true"
+        android:key="@string/pref_default_app_definition"
+        android:summary="@string/pref_summary_default_app_definition"
+        android:title="@string/pref_title_default_app_definition" />
+
+    <EditTextPreference
+        android:dependency="@string/pref_default_app_definition"
+        android:defaultValue="@string/app_name"
+        android:key="@string/pref_app_name"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:title="@string/pref_title_app_name" />
+
+    <EditTextPreference
+        android:dependency="@string/pref_default_app_definition"
+        android:defaultValue="@string/app_version"
+        android:key="@string/pref_app_version"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:title="@string/pref_title_app_version" />
+
+    <EditTextPreference
+        android:dependency="@string/pref_default_app_definition"
+        android:defaultValue="@string/org_name"
+        android:key="@string/pref_org_name"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:title="@string/pref_title_org_name" />
 
 </PreferenceScreen>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_matching_engine.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_matching_engine.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:id="@+id/matching_engine_general_preference_screen">
+    android:id="@+id/matching_engine_preference_screen">
 
     <SwitchPreference
         android:id="@+id/preference_matching_engine_location_verification"
@@ -19,5 +19,13 @@
         android:title="@string/preference_net_switching_allowed_title"
         android:summary="@string/preference_net_switching_allowed_summary"
         android:defaultValue="false" />
+
+    <ListPreference
+        android:defaultValue="PROXIMITY"
+        android:entries="@array/pref_find_cloudlet_method_titles"
+        android:entryValues="@array/pref_find_cloudlet_method_values"
+        android:key="@string/pref_find_cloudlet_mode"
+        android:summary="@string/pref_find_cloudlet_summary"
+        android:title="@string/pref_find_cloudlet_title" />
 
 </PreferenceScreen>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
@@ -37,11 +37,11 @@
         android:defaultValue="ping"
         android:entries="@array/pref_latency_test_method_titles"
         android:entryValues="@array/pref_latency_test_method_values"
-        android:key="@string/latency_method"
+        android:key="@string/pref_latency_method"
         android:negativeButtonText="@null"
         android:positiveButtonText="@null"
-        android:summary="@string/pref_summary_latency_method"
-        android:title="@string/pref_title_latency_method" />
+        android:summary="@string/pref_latency_method_summary"
+        android:title="@string/pref_latency_method_title" />
 
     <SwitchPreference
         android:key="@string/pref_latency_autostart"

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "2.0.8"
-project.ext.melVersion = "1.0.8"
+project.ext.matchingengineVersion = "2.0.14"
+project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.20.0'
 
 //

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "2.0.14"
+project.ext.matchingengineVersion = "2.1.0"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.20.0'
 
@@ -44,7 +44,7 @@ allprojects {
                 username artifactory_user
                 password artifactory_password
             }
-            url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
+            url "https://artifactory.mobiledgex.net/artifactory/maven-releases/"
         }
     }
 }

--- a/android/MobiledgeXSDKDemo/computervision/build.gradle
+++ b/android/MobiledgeXSDKDemo/computervision/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.1.1"
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -24,6 +24,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/EventItem.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/EventItem.java
@@ -1,0 +1,40 @@
+package com.mobiledgex.computervision;
+
+import android.text.format.DateFormat;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * An Activity item.
+ */
+public class EventItem {
+    public final long timestamp;
+    public final String timestampText;
+    public final String id;
+    public final String content;
+    public enum EventType {
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR
+    }
+    public EventType eventType;
+
+    public EventItem(EventType type, String content) {
+        eventType = type;
+        timestamp = System.currentTimeMillis();
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        cal.setTimeInMillis(timestamp);
+        // TODO: Update to use device's configured date and time format.
+//        this.timestampText = DateFormat.format("MM-dd-yyyy HH:mm:ss", cal).toString();
+        timestampText = DateFormat.format("HH:mm:ss", cal).toString();
+        id = ""+timestamp;
+        this.content = content;
+    }
+
+    @Override
+    public String toString() {
+        return timestamp + " " + content;
+    }
+}

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageServerInterface.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageServerInterface.java
@@ -58,15 +58,16 @@ public interface ImageServerInterface {
     /**
      * Shows a message to the user.
      * @param message  The message to show.
-     * @param length  The length of time to show it for.
      */
-    void showMessage(String message, int length);
+    void showMessage(String message);
 
     /**
      * Shows a message to the user.
      * @param error  The message to show.
      */
     void showError(String error);
+
+    void reportConnectionError(String error, ImageSender imageSender);
 
     /**
      * The type of server that is processing the images.

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/MyEventRecyclerViewAdapter.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/MyEventRecyclerViewAdapter.java
@@ -1,0 +1,105 @@
+package com.mobiledgex.computervision;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.graphics.Color;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.util.List;
+
+/**
+ * {@link RecyclerView.Adapter} that can display a {@link EventItem}.
+ */
+public class MyEventRecyclerViewAdapter extends RecyclerView.Adapter<MyEventRecyclerViewAdapter.ViewHolder> {
+
+    private final List<EventItem> mValues;
+
+    public MyEventRecyclerViewAdapter(List<EventItem> items) {
+        mValues = items;
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.fragment_event, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(final ViewHolder holder, int position) {
+        holder.mItem = mValues.get(position);
+        holder.mTimestampView.setText(mValues.get(position).timestampText);
+        holder.mContentView.setText(mValues.get(position).content);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mValues.size();
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position, @NonNull List<Object> payloads) {
+        super.onBindViewHolder(holder, position, payloads);
+        if(position%2 == 0){
+            holder.mView.setBackgroundColor(Color.parseColor("#FFFFFF"));
+        } else {
+            holder.mView.setBackgroundColor(Color.parseColor("#EEEEEE"));
+        }
+    }
+
+    public void itemAdded() {
+        int id = mValues.size();
+        this.notifyItemInserted(id);
+    }
+
+    public String getAllItemsAsText() {
+        StringBuilder sb = new StringBuilder();
+        for (EventItem eventItem : mValues) {
+            sb.append(eventItem.timestampText + " " + eventItem.content + "\n");
+        }
+        return sb.toString();
+    }
+
+    public class ViewHolder extends RecyclerView.ViewHolder {
+        public final View mView;
+        public final TextView mTimestampView;
+        public final TextView mContentView;
+        public EventItem mItem;
+
+        public ViewHolder(final View view) {
+            super(view);
+            mView = view;
+            mTimestampView = (TextView) view.findViewById(R.id.timestamp);
+            mContentView = (TextView) view.findViewById(R.id.content);
+
+            //Long Press
+            view.setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View v) {
+                    // Gets a handle to the clipboard service.
+                    ClipboardManager clipboard = (ClipboardManager)
+                            view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                    // Creates a new text clip to put on the clipboard
+                    ClipData clip = ClipData.newPlainText("simple text", getAllItemsAsText());
+                    // Set the clipboard's primary clip.
+                    clipboard.setPrimaryClip(clip);
+                    Toast.makeText(view.getContext(), "Items copied to clipboard.", Toast.LENGTH_SHORT).show();
+                    return false;
+                }
+            });
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + " '" + mContentView.getText() + "'";
+        }
+    }
+}

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -218,17 +218,11 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
         // TODO: Create separate preference for Object Detection Host
         String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
         mHostDetectionEdge = prefs.getString(prefKeyOpenPoseHostEdge, DEF_OBJECT_DETECTION_HOST_EDGE);
-        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+mHostDetectionEdge);
+        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
 
-        // See if we have an Extra with the closest cloudlet passed in to override the preference.
         Intent intent = getActivity().getIntent();
-        String edgeCloudletHostname = intent.getStringExtra(EXTRA_EDGE_CLOUDLET_HOSTNAME);
-        Log.i(TAG, "Extra "+EXTRA_EDGE_CLOUDLET_HOSTNAME+"="+edgeCloudletHostname);
-        if(edgeCloudletHostname != null) {
-            Log.i(TAG, "Using Extra "+edgeCloudletHostname+" for mHostDetectionEdge.");
-            mHostDetectionEdge = edgeCloudletHostname;
-        }
-        
+        getCommonIntentExtras(intent);
+
         mImageSenderEdge = new ImageSender.Builder()
                 .setActivity(getActivity())
                 .setImageServerInterface(this)
@@ -260,6 +254,8 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
         menu.findItem(R.id.action_camera_training_guest).setVisible(false);
         menu.findItem(R.id.action_camera_remove_training_data).setVisible(false);
         menu.findItem(R.id.action_camera_remove_training_guest_data).setVisible(false);
+        menu.findItem(R.id.action_find_cloudlet).setVisible(false);
+        menu.findItem(R.id.action_get_app_inst_list).setVisible(false);
 
         //No Cloud available for benchmarking
         menu.findItem(R.id.action_benchmark_cloud).setVisible(false);

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -219,17 +219,11 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
 
         String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
         mHostDetectionEdge = prefs.getString(prefKeyOpenPoseHostEdge, DEF_OPENPOSE_HOST_EDGE);
-        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+mHostDetectionEdge);
+        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
 
-        // See if we have an Extra with the closest cloudlet passed in to override the preference.
         Intent intent = getActivity().getIntent();
-        String edgeCloudletHostname = intent.getStringExtra(EXTRA_EDGE_CLOUDLET_HOSTNAME);
-        Log.i(TAG, "Extra "+EXTRA_EDGE_CLOUDLET_HOSTNAME+"="+edgeCloudletHostname);
-        if(edgeCloudletHostname != null) {
-            Log.i(TAG, "Using Extra "+edgeCloudletHostname+" for mHostDetectionEdge.");
-            mHostDetectionEdge = edgeCloudletHostname;
-        }
-        
+        getCommonIntentExtras(intent);
+
         // Check for other optional parameters
         int strokeWidth = intent.getIntExtra(EXTRA_POSE_STROKE_WIDTH, PoseRenderer.DEFAULT_STROKE_WIDTH);
         int jointRadius = intent.getIntExtra(EXTRA_POSE_JOINT_RADIUS, PoseRenderer.DEFAULT_JOINT_RADIUS);
@@ -267,6 +261,8 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
         menu.findItem(R.id.action_camera_training_guest).setVisible(false);
         menu.findItem(R.id.action_camera_remove_training_data).setVisible(false);
         menu.findItem(R.id.action_camera_remove_training_guest_data).setVisible(false);
+        menu.findItem(R.id.action_find_cloudlet).setVisible(false);
+        menu.findItem(R.id.action_get_app_inst_list).setVisible(false);
 
         //No Cloud available for benchmarking
         menu.findItem(R.id.action_benchmark_cloud).setVisible(false);

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
@@ -30,6 +30,8 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import androidx.appcompat.app.ActionBar;
+
+import android.util.Log;
 import android.view.MenuItem;
 
 import java.util.List;
@@ -47,6 +49,7 @@ import java.util.List;
  */
 public class SettingsActivity extends AppCompatPreferenceActivity {
 
+    private static final String TAG = "CV/SettingsActivity";
     /**
      * A preference value change listener that updates the preference's summary
      * to reflect its new value.
@@ -160,6 +163,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
      * Make sure to deny any unknown fragments here.
      */
     protected boolean isValidFragment(String fragmentName) {
+        Log.i(TAG, "isValidFragment("+fragmentName+")");
         return PreferenceFragment.class.getName().equals(fragmentName)
                 || FaceDetectionSettingsFragment.class.getName().equals(fragmentName);
     }
@@ -173,6 +177,14 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             setHasOptionsMenu(true);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             prefs.registerOnSharedPreferenceChangeListener(this);
+
+            String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
+            String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
+            String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
+
+            bindPreferenceSummaryToValue(findPreference(prefKeyHostCloud));
+            bindPreferenceSummaryToValue(findPreference(prefKeyHostEdge));
+            bindPreferenceSummaryToValue(findPreference(prefKeyOpenPoseHostEdge));
         }
 
         @Override

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/drawable/ic_baseline_more_24.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/drawable/ic_baseline_more_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M22,3L7,3c-0.69,0 -1.23,0.35 -1.59,0.88L0,12l5.41,8.11c0.36,0.53 0.97,0.89 1.66,0.89L22,21c1.1,0 2,-0.9 2,-2L24,5c0,-1.1 -0.9,-2 -2,-2zM9,13.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM14,13.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM19,13.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5z"/>
+</vector>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_event.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_event.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        app:srcCompat="@android:drawable/ic_menu_info_details" />
+
+    <TextView
+        android:id="@+id/timestamp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:layout_weight="3"
+        android:text="00:00:00"
+        android:textAppearance="?attr/textAppearanceListItem"
+        android:textColor="@android:color/black"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:layout_weight="17"
+        android:text="Sample activity text"
+        android:textAppearance="?attr/textAppearanceListItem"
+        android:textColor="@android:color/black"
+        android:textIsSelectable="false" />
+</LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_event_list.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_event_list.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/list"
+    android:name="com.mobiledgex.computervision.EventFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp"
+    app:layoutManager="LinearLayoutManager"
+    tools:context=".ImageProcessorActivity"
+    tools:listitem="@layout/fragment_event" />

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_image_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_image_processor.xml
@@ -35,7 +35,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical" >
+        android:orientation="vertical">
 
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
@@ -65,29 +65,10 @@
                 android:textSize="28sp" />
 
             <TextView
-                android:id="@+id/cloud_latency"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/network_latency"
-                android:text="Cloud:"
-                android:textColor="@android:color/white"
-                android:textSize="24sp" />
-
-            <TextView
-                android:id="@+id/cloud_std_dev"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/cloud_latency"
-                android:text="Stddev: 0 ms"
-                android:textColor="@android:color/white"
-                android:textSize="20sp" />
-
-            <TextView
                 android:id="@+id/edge_latency"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/network_latency"
-                android:layout_alignParentEnd="true"
                 android:text="Edge:"
                 android:textColor="@android:color/white"
                 android:textSize="24sp" />
@@ -97,6 +78,25 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/edge_latency"
+                android:text="Stddev: 0 ms"
+                android:textColor="@android:color/white"
+                android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/cloud_latency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/network_latency"
+                android:layout_alignParentEnd="true"
+                android:text="Cloud:"
+                android:textColor="@android:color/white"
+                android:textSize="24sp" />
+
+            <TextView
+                android:id="@+id/cloud_std_dev"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/cloud_latency"
                 android:layout_alignParentEnd="true"
                 android:text="Stddev: 0 ms"
                 android:textColor="@android:color/white"
@@ -119,15 +119,15 @@
                     android:textSize="22sp" />
 
                 <TextView
-                    android:id="@+id/cloud_latency2"
+                    android:id="@+id/edge_latency2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Cloud:"
+                    android:text="Edge:"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
 
                 <TextView
-                    android:id="@+id/cloud_std_dev2"
+                    android:id="@+id/edge_std_dev2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Stddev: 0 ms"
@@ -143,15 +143,15 @@
                 android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/edge_latency2"
+                    android:id="@+id/cloud_latency2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Edge:"
+                    android:text="Cloud:"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
 
                 <TextView
-                    android:id="@+id/edge_std_dev2"
+                    android:id="@+id/cloud_std_dev2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Stddev: 0 ms"
@@ -170,25 +170,44 @@
 
             <TextView
                 android:id="@+id/progressTextView"
-                android:textColor="@android:color/white"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_above="@+id/cloudStatsLayout"
                 android:layout_centerHorizontal="true"
-                android:text="TextView" />
+                android:text="TextView"
+                android:textColor="@android:color/white" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/events_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:layout_above="@+id/statusTextView"
+                android:background="#FFFFFF" />
 
             <TextView
                 android:id="@+id/statusTextView"
-                android:textColor="@android:color/white"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_above="@+id/progressTextView"
                 android:layout_centerHorizontal="true"
-                android:text="" />
+                android:maxLines="1"
+                android:text=""
+                android:textColor="@android:color/white"
+                android:textIsSelectable="true" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_above="@+id/statusTextView"
+                android:layout_alignParentStart="true"
+                android:layout_marginStart="5dp"
+                android:scaleX="-1"
+                android:clickable="true"
+                app:srcCompat="@drawable/ic_baseline_more_24" />
 
         </RelativeLayout>
 
     </LinearLayout>
-
 
 </FrameLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/menu/camera_menu.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/menu/camera_menu.xml
@@ -13,6 +13,12 @@
         android:icon="@drawable/ic_menu_settings"
         android:title="Settings"
         app:showAsAction="ifRoom" />
+    <item android:id="@+id/action_find_cloudlet"
+        android:title="Find Closest Cloudlet" />
+    <item android:id="@+id/action_get_app_inst_list"
+        android:title="Get App Instances" />
+    <item android:id="@+id/action_manual_failover"
+        android:title="Manual Failover" />
     <item android:id="@+id/action_camera_training"
         android:title="Training Mode" />
     <item android:id="@+id/action_camera_remove_training_data"

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/dimens.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="text_margin">16dp</dimen>
+</resources>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
 
     <string name="preference_fd_settings">Computer Vision Settings</string>
 
-    <string name="pref_summary_latency_method">Select socket connection or ICMP ping</string>
     <string name="preference_fd_front_camera">fd_front_camera</string>
     <string name="preference_fd_multi_face">fd_multi_face</string>
     <string name="preference_fd_multi_face_title">Multi-face</string>
@@ -32,6 +31,9 @@
     <string name="preference_fd_use_rolling_avg">fd_use_rolling_avg</string>
     <string name="preference_fd_use_rolling_avg_title">Use Rolling Average</string>
     <string name="preference_fd_use_rolling_avg_summary">Show individual measurements or rolling average</string>
+    <string name="preference_fd_show_cloud_output">fd_show_cloud_output</string>
+    <string name="preference_fd_show_cloud_output_title">Show Cloud Output</string>
+    <string name="preference_fd_show_cloud_output_summary">Show or hide results from public cloud image processing</string>
     <string name="preference_fd_host_training">fd_host_training</string>
     <string name="preference_fd_host_cloud">fd_host_cloud</string>
     <string name="preference_fd_host_cloud_title">Cloud Server</string>
@@ -54,7 +56,7 @@
     </string-array>
     <string name="fd_latency_method">fd_latency_method</string>
     <string name="preference_openpose_host_edge">fd_openpose_host_edge</string>
-    <string name="preference_openpose_host_edge_title">OpenPose GPU Server</string>
+    <string name="preference_openpose_host_edge_title">GPU Server (OpenPose, PyTorch)</string>
     <string name="preference_openpose_host_edge_summary">Enter a custom IP or hostname.</string>
     <string name="train_guest_start">Start</string>
     <string name="train_guest_title">Guest Name</string>
@@ -65,8 +67,9 @@
     <string name="verify_delete_title">Delete Training Data</string>
     <string name="verify_delete_message">Are you sure you want to delete your face training data from the server?</string>
 
-    <string name="pref_title_latency_method">Latency Test Method</string>
-    <string name="latency_method">latency_method</string>
+    <string name="pref_latency_method">latency_method</string>
+    <string name="pref_latency_method_title">Latency Test Method</string>
+    <string name="pref_latency_method_summary">%s</string>
     <string-array name="pref_latency_test_method_titles">
         <item>System Ping (ICMP)</item>
         <item>Socket</item>
@@ -78,7 +81,7 @@
 
     <string name="preference_fd_connection_mode">fd_connection_mode</string>
     <string name="preference_fd_connection_mode_title">Connection Mode</string>
-    <string name="preference_fd_connection_mode_summary">Choose how to connect to the server.</string>
+    <string name="preference_fd_connection_mode_summary">%s</string>
     <string-array name="pref_fd_connection_mode_titles">
         <item>REST</item>
         <item>Persistent TCP</item>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
     <string name="preference_fd_show_cloud_output">fd_show_cloud_output</string>
     <string name="preference_fd_show_cloud_output_title">Show Cloud Output</string>
     <string name="preference_fd_show_cloud_output_summary">Show or hide results from public cloud image processing</string>
+    <string name="preference_fd_auto_failover">fd_auto_failover</string>
+    <string name="preference_fd_auto_failover_title">Auto Failover</string>
+    <string name="preference_fd_auto_failover_summary">Automatically switch to next available server when failure encountered</string>
     <string name="preference_fd_host_training">fd_host_training</string>
     <string name="preference_fd_host_cloud">fd_host_cloud</string>
     <string name="preference_fd_host_cloud_title">Cloud Server</string>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
@@ -54,6 +54,11 @@
         android:summary="@string/preference_fd_use_rolling_avg_summary"
         android:defaultValue="false" />
     <SwitchPreference
+        android:key="@string/preference_fd_auto_failover"
+        android:title="@string/preference_fd_auto_failover_title"
+        android:summary="@string/preference_fd_auto_failover_summary"
+        android:defaultValue="false" />
+    <SwitchPreference
         android:key="@string/preference_fd_show_cloud_output"
         android:title="@string/preference_fd_show_cloud_output_title"
         android:summary="@string/preference_fd_show_cloud_output_summary"

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
@@ -26,8 +26,8 @@
         android:key="@string/fd_latency_method"
         android:negativeButtonText="@null"
         android:positiveButtonText="@null"
-        android:summary="@string/pref_summary_latency_method"
-        android:title="@string/pref_title_latency_method" />
+        android:summary="@string/pref_latency_method_summary"
+        android:title="@string/pref_latency_method_title" />
     <SwitchPreference
         android:key="@string/preference_fd_multi_face"
         android:title="@string/preference_fd_multi_face_title"
@@ -53,6 +53,11 @@
         android:title="@string/preference_fd_use_rolling_avg_title"
         android:summary="@string/preference_fd_use_rolling_avg_summary"
         android:defaultValue="false" />
+    <SwitchPreference
+        android:key="@string/preference_fd_show_cloud_output"
+        android:title="@string/preference_fd_show_cloud_output_title"
+        android:summary="@string/preference_fd_show_cloud_output_summary"
+        android:defaultValue="true" />
     <ListPreference
         android:defaultValue="invalid"
         android:entries="@array/pref_fd_reset_both_hosts_choices"
@@ -84,6 +89,6 @@
         android:key="@string/preference_fd_show_latency_stats_dialog"
         android:title="@string/preference_fd_show_latency_stats_dialog_title"
         android:summary="@string/preference_fd_show_latency_stats_dialog_summary"
-        android:defaultValue="false" />
+        android:defaultValue="true" />
 
 </PreferenceScreen>


### PR DESCRIPTION
This is the version I demoed at the Engineering meeting, plus Sunay's "Manual Failover" request, and correct WifiOnly handling.

More updates may be required as the app goes through QA, but hopefully they'll be minor.

- App name, version, organization can all be changed in General Settings.
- “About” dialog updated to show these values.
- HA: When Computer Vision server connectivity is lost, failover to next closest cloudlet.
- Added “Find Cloudlet” capabilities to Computer Vision activities.
- Added expandable log viewer to Computer Vision activities. Added expandable log viewer to Computer Vision activities. Long press to copy all contents to clipboard. If using Vysor or Scrcpy, it will also be copied to your desktop clipboard.
- New Setting to toggle display of public cloud processing output.
- Removed PQoE until TDG restores backend.
- New setting for choosing findCloudlet mode: PROXIMITY or PERFORMANCE.
- Use WifiOnly when a user has an unsupported MCCMNC