### PR TITLE
Fix NPE crashes, add long-press to clear log viewer.

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 28
-        versionCode 57
-        versionName "1.1.8"
+        versionCode 58
+        versionName "1.1.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/release/output.json
+++ b/android/MobiledgeXSDKDemo/app/release/output.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "properties": [],
-      "versionCode": 57,
-      "versionName": "57",
+      "versionCode": 58,
+      "versionName": "58",
       "enabled": true,
       "outputFile": "MobiledgeXSDKDemo-release.apk"
     }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -1464,7 +1464,7 @@ public class MainActivity extends AppCompatActivity
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
             newHost = prefs.getString(keyName, defaultHost);
             boolean reachable = ImageSender.isReachable(newHost,
-                    ImageSender.getFaceDetectionServerPort(newHost), 3000);
+                    ImageSender.getComputerVisionServerPort(newHost), 3000);
             if(!reachable) {
                 Log.e(TAG, newHost+" not reachable. Resetting "+keyName+" to default.");
                 prefs.edit().putString(keyName, defaultHost).apply();

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -183,7 +183,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
     }
 
     /**
-     * Shows a {@link Toast} on the UI thread.
+     * Adds a informational message to the log viewer.
      *
      * @param text The message to show.
      */
@@ -192,6 +192,11 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
         addEventItem(INFO, text);
     }
 
+    /**
+     * Adds an error message to the log viewer.
+     *
+     * @param text The message to show.
+     */
     @Override
     public void showError(final String text) {
         addEventItem(ERROR, text);
@@ -959,6 +964,31 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
                 }
             }
         });
+        mLogExpansionButton.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                new androidx.appcompat.app.AlertDialog.Builder(getContext())
+                        .setTitle(R.string.verify_clear_logs_title)
+                        .setMessage(R.string.verify_clear_logs_message)
+                        .setNegativeButton(android.R.string.cancel,
+                                new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        dialog.dismiss();
+                                    }
+                                })
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                mEventItemList.clear();
+                                mEventRecyclerViewAdapter.notifyDataSetChanged();
+                                Toast.makeText(getContext(), "Log viewer cleared", Toast.LENGTH_LONG).show();
+                            }
+                        })
+                        .show();
+                return true;
+            }
+        });
         Timer myTimer = new Timer();
         myTimer.schedule(new TimerTask() {
             @Override
@@ -973,6 +1003,10 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
 
     protected void logViewAnimate(final int start, final int end) {
         Log.i(TAG, "logViewAnimate start="+start+" end="+end);
+        if (getActivity() == null) {
+            Log.e(TAG, "logViewAnimate called after Activity has gone away.");
+            return;
+        }
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -980,6 +1014,10 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
                 va.setDuration(500);
                 va.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                     public void onAnimationUpdate(ValueAnimator animation) {
+                        if (animation == null) {
+                            Log.e(TAG, "onAnimationUpdate called with null animation.");
+                            return;
+                        }
                         Integer value = (Integer) animation.getAnimatedValue();
                         Log.i(TAG, "value="+value);
                         mEventsRecyclerView.getLayoutParams().height = value.intValue();
@@ -1247,11 +1285,6 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             Log.i(TAG, "getAppInstList cloudletList.getCloudletsCount()=" + cloudletList.getCloudletsCount());
             Log.i(TAG, "getAppInstList mEdgeHostList=" + mEdgeHostList);
 
-            // TODO: Remove
-//            mEdgeHostList.clear();
-//            mEdgeHostList.add("192.168.1.66");
-//            mEdgeHostList.add("acrotopia.com");
-
             mHostDetectionEdge = mEdgeHostList.get(mEdgeHostListIndex);
             Log.i(TAG, "getAppInstList mHostDetectionEdge=" + mHostDetectionEdge);
             restartImageSenderEdge();
@@ -1264,7 +1297,6 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             return false;
         }
     }
-
 
     public ImageSender getImageSenderEdge() {
         return mImageSenderEdge;

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -181,7 +181,11 @@ public class ImageSender {
 
         mImageServerInterface = builder.imageServerInterface;
 
-        mAccount = GoogleSignIn.getLastSignedInAccount(builder.activity);
+        try {
+            mAccount = GoogleSignIn.getLastSignedInAccount(builder.activity);
+        } catch (Exception e) {
+            Log.e(TAG, "NPE occurred in GoogleSignIn code.", e);
+        }
         if(mAccount != null) {
             Log.i(TAG, "mAccount=" + mAccount.getDisplayName()+" "+mAccount.getId());
         } else {
@@ -374,10 +378,10 @@ public class ImageSender {
     }
 
     //TODO: Get the port value from the appInst
-    public static int getFaceDetectionServerPort(String hostName) {
+    public static int getComputerVisionServerPort(String hostName) {
         int port;
         port = 8008;
-        Log.i(TAG, "getFaceDetectionServerPort("+hostName+")="+port);
+        Log.i(TAG, "getComputerVisionServerPort("+hostName+")="+port);
         return port;
     }
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="sign_in_required_message">Return to main menu and choose \"Sign in with Google\".</string>
     <string name="verify_delete_title">Delete Training Data</string>
     <string name="verify_delete_message">Are you sure you want to delete your face training data from the server?</string>
+    <string name="verify_clear_logs_title">Clear Log Viewer</string>
+    <string name="verify_clear_logs_message">Are you sure you want to clear the log entries?</string>
 
     <string name="pref_latency_method">latency_method</string>
     <string name="pref_latency_method_title">Latency Test Method</string>


### PR DESCRIPTION
Main concern here is to fix some NullPointerException crashes that had been submitted via Android's crash report tool. Some, I don't understand how they're possible to happen, but these updates will catch them and not crash.