### PR TITLE
EDGECLOUD-3162: Make Ping Pong Working Example have UseWifiOnly(true)

### DIFF
--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
@@ -162,15 +162,10 @@ namespace MobiledgeXPingPongGame {
 #endif
 
       clog("LocationService is running. Status is: " + Input.location.status);
-
-      var mobiledgexTask = MobiledgeXAPICalls();
-      while (!mobiledgexTask.IsCompleted)
-      {
-        yield return null;
-      }
+      MobiledgeXAPICalls();
     }
 
-    async Task MobiledgeXAPICalls()
+    async void MobiledgeXAPICalls()
     {
       // RegisterAndFindCloudlet and VerifyLocation:
       FindCloudletReply findCloudletReply;

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
@@ -112,7 +112,6 @@ namespace MobiledgeXPingPongGame {
       // and a local DME cannot be located. Set to false if using a supported
       // SIM Card.
       integration = new MobiledgeXIntegration();
-      integration.UseWifiOnly(true);
 
       // Use local server, by IP. This must be started before use:
       if (useAltServer)
@@ -203,12 +202,15 @@ namespace MobiledgeXPingPongGame {
       {
         // This app should fallback to public cloud, as the DME doesn't exist for your
         // SIM card + carrier.
-        clog("Cannot register to DME host: " + de.Message + ", Stack: " + de.StackTrace);
+        clog("Cannot register to DME host: " + de.Message + ". Falling back to Wifi DME. Stack trace: " + de.StackTrace);
+        clog("Please reach out to us on Slack or e-mail Support so that we can create a DME with your mcc-mnc value.");
         if (de.InnerException != null)
         {
           clog("Original Exception: " + de.InnerException.Message);
         }
-        // Handle fallback to public cloud application server.
+        // Fallback to Wifi DME
+        integration.UseWifiOnly(true);
+        MobiledgeXAPICalls();
         return;
       }
       catch (Exception e)

--- a/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
+++ b/unity/PingPongGameExample/PingPongGame/Assets/Scripts/GameManager.cs
@@ -112,10 +112,8 @@ namespace MobiledgeXPingPongGame {
       // and a local DME cannot be located. Set to false if using a supported
       // SIM Card.
       integration = new MobiledgeXIntegration();
-
-#if UNITY_EDITOR
       integration.UseWifiOnly(true);
-#endif
+
       // Use local server, by IP. This must be started before use:
       if (useAltServer)
       {
@@ -164,10 +162,15 @@ namespace MobiledgeXPingPongGame {
 #endif
 
       clog("LocationService is running. Status is: " + Input.location.status);
-      MobiledgeXAPICalls();
+
+      var mobiledgexTask = MobiledgeXAPICalls();
+      while (!mobiledgexTask.IsCompleted)
+      {
+        yield return null;
+      }
     }
 
-    async void MobiledgeXAPICalls()
+    async Task MobiledgeXAPICalls()
     {
       // RegisterAndFindCloudlet and VerifyLocation:
       FindCloudletReply findCloudletReply;


### PR DESCRIPTION
UseWifiOnly for Completed PingPong game. We want the initial introduction to MobiledgeX to be as seemless as possible. Once a developer decides to dig deeper in the.SkeletonApp, our docs we explain why UseWifiOnly is only for testing and there we ask them to send their mcc+mnc to be mapped in the backend

