### PR TITLE
EDGECLOUD-3228 EDGECLOUD-3110 GPU-specific app instance support

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 28
-        versionCode 58
-        versionName "1.1.9"
+        versionCode 59
+        versionName "1.1.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/androidTest/java/com/mobiledgex/sdkdemo/MatchingEngineUnitTest.java
+++ b/android/MobiledgeXSDKDemo/app/src/androidTest/java/com/mobiledgex/sdkdemo/MatchingEngineUnitTest.java
@@ -62,18 +62,6 @@ public class MatchingEngineUnitTest {
             Looper.prepare();
     }
 
-//    @Before
-//    public void grantPermissions() {
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-//            UiAutomation uiAutomation = getInstrumentation().getUiAutomation();
-//            uiAutomation.executeShellCommand(
-//                    "pm grant " + getInstrumentation().getTargetContext().getPackageName()
-//                            + " android.permission.READ_PHONE_STATE");
-//            uiAutomation.executeShellCommand(
-//                    "pm grant " + getInstrumentation().getTargetContext().getPackageName()
-//                            + " android.permission.ACCESS_COARSE_LOCATION");
-//        }
-//    }
     @Before
     public void grantPermissions() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MatchingEngineHelper.java
@@ -177,13 +177,8 @@ public class MatchingEngineHelper {
             try {
                 String host = mHostname; // Override host.
                 int port = mMatchingEngine.getPort(); // Keep same port.
-                String orgName = "MobiledgeX";
                 //Note that mCarrierName came from preferences in MainActivity.
 
-                // SDK will populate the appVersion automatically if we pass in "".
-                // However, the backend we want to connect to is versioned as "2.0",
-                // so we are overriding with that value here.
-                String appVersion = "2.0";
                 boolean reportCookie = false;
 
                 if(reqType == RequestType.REQ_REGISTER_CLIENT) {
@@ -295,7 +290,6 @@ public class MatchingEngineHelper {
         AppClient.AppInstListRequest appInstListRequest
                 = mMatchingEngine.createDefaultAppInstListRequest(mContext, location)
                 .setCarrierName(mCarrierName).setLimit(mAppInstancesLimit).build();
-        // TODO: Make setLimit value a preference.
         if(appInstListRequest != null) {
             AppClient.AppInstListReply cloudletList = mMatchingEngine.getAppInstList(appInstListRequest,
                     host, port, 10000);

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">MobiledgeX SDK Demo</string>
+    <string name="app_name">ComputerVision</string>
     <string name="app_version">2.0</string>
     <string name="org_name">MobiledgeX</string>
 

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "2.1.0"
+project.ext.matchingengineVersion = "2.1.2"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.20.0'
 
@@ -44,7 +44,7 @@ allprojects {
                 username artifactory_user
                 password artifactory_password
             }
-            url "https://artifactory.mobiledgex.net/artifactory/maven-releases/"
+            url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
         }
     }
 }

--- a/android/MobiledgeXSDKDemo/computervision/build.gradle
+++ b/android/MobiledgeXSDKDemo/computervision/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.1.2"
+        versionName "1.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -184,7 +184,9 @@ public class ImageSender {
         try {
             mAccount = GoogleSignIn.getLastSignedInAccount(builder.activity);
         } catch (Exception e) {
+            // This may occur when the user quits during a restart attempt and the activity has gone away.
             Log.e(TAG, "NPE occurred in GoogleSignIn code.", e);
+            return;
         }
         if(mAccount != null) {
             Log.i(TAG, "mAccount=" + mAccount.getDisplayName()+" "+mAccount.getId());
@@ -202,7 +204,13 @@ public class ImageSender {
         handlerThreadPersistentTcp.start();
 
         // Instantiate the RequestQueue.
-        mRequestQueue = Volley.newRequestQueue(builder.activity);
+        try {
+            mRequestQueue = Volley.newRequestQueue(builder.activity);
+        } catch (NullPointerException e) {
+            // This may occur when the user quits during a restart attempt and the activity has gone away.
+            Log.e(TAG, "NPE occurred in Volley.newRequestQueue code.", e);
+            return;
+        }
 
         Log.i(TAG, "preferencesConnectionMode="+ preferencesConnectionMode);
         if(mCloudLetType == ImageServerInterface.CloudletType.PUBLIC) {
@@ -350,6 +358,11 @@ public class ImageSender {
             mDjangoUrl = "/object/detect/";
         } else {
             Log.e(TAG, "Invalid CameraMode: "+mode);
+        }
+        try {
+            throw new Exception("Null cameramode");
+        } catch (Exception e) {
+            e.printStackTrace();
         }
         Log.i(TAG, "setCameraMode("+mCameraMode+") mOpcode="+mOpcode+" mDjangoUrl="+ mDjangoUrl +" "+mCloudLetType+" host="+mHost);
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_object_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_object_processor.xml
@@ -98,6 +98,24 @@
                     android:textSize="20sp" />
             </LinearLayout>
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/events_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:layout_above="@+id/statusTextView"
+                android:background="#FFFFFF" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_above="@+id/statusTextView"
+                android:layout_alignParentStart="true"
+                android:layout_marginStart="5dp"
+                android:scaleX="-1"
+                android:clickable="true"
+                app:srcCompat="@drawable/ic_baseline_more_24" />
+
         </RelativeLayout>
 
     </LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
@@ -98,6 +98,24 @@
                     android:textSize="20sp" />
             </LinearLayout>
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/events_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:layout_above="@+id/statusTextView"
+                android:background="#FFFFFF" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_above="@+id/statusTextView"
+                android:layout_alignParentStart="true"
+                android:layout_marginStart="5dp"
+                android:scaleX="-1"
+                android:clickable="true"
+                app:srcCompat="@drawable/ic_baseline_more_24" />
+
         </RelativeLayout>
 
     </LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
-    <string name="app_name">Computer Vision</string>
+    <string name="app_name">ComputerVision</string>
+    <string name="app_version">2.0</string>
+    <string name="org_name">MobiledgeX</string>
+
     <string name="title_activity_face_detection">Face Detection</string>
     <string name="title_activity_face_recognition">Face Recognition</string>
     <string name="title_activity_object_detection">Object Detection</string>

--- a/android/WorkshopCompleted/.idea/codeStyles/Project.xml
+++ b/android/WorkshopCompleted/.idea/codeStyles/Project.xml
@@ -1,0 +1,116 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/android/WorkshopCompleted/.idea/jarRepositories.xml
+++ b/android/WorkshopCompleted/.idea/jarRepositories.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://artifactory.mobiledgex.net/maven-releases/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/android/WorkshopCompleted/app/build.gradle
+++ b/android/WorkshopCompleted/app/build.gradle
@@ -37,13 +37,17 @@ dependencies {
     implementation 'com.google.maps.android:android-maps-utils:0.5+'
     implementation 'com.google.android.gms:play-services-maps:15.0.1'
 
+    implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
+    implementation 'androidx.ads:ads-identifier:1.0.0-alpha04'
+
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:2.0'
+    implementation 'com.mobiledgex:matchingengine:2.1.2-hash-id'
+    implementation "com.mobiledgex:mel:1.0.11"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
 
     // MobiledgeX Computer Vision library
-    implementation 'com.mobiledgex:computervision:1.0.6'
+    implementation 'com.mobiledgex:computervision:1.1.2'
     implementation 'com.android.volley:volley:1.1.1'
 }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
@@ -76,14 +76,14 @@ public class FaceProcessorActivity extends AppCompatActivity {
         MatchingEngine me = new MatchingEngine(this);
         AppConnectionManager appConnect = me.getAppConnectionManager();
 
-        String appName = "MobiledgeX SDK Demo";
+        String appName = "ComputerVision";
         String appVersion = "2.0";
         String orgName = "MobiledgeX";
         Location location = new Location("MEX");
         location.setLatitude(52.52);
         location.setLongitude(13.4040);    //Berlin
 
-        Future<AppClient.FindCloudletReply> future = me.registerAndFindCloudlet(this, orgName, appName, appVersion,  location, "", 0, "", "", null);
+        Future<AppClient.FindCloudletReply> future = me.registerAndFindCloudlet(this, orgName, appName, appVersion,  location, "", 0, "", "", null, MatchingEngine.FindCloudletMode.PROXIMITY);
         AppClient.FindCloudletReply findCloudletReply;
         try {
             findCloudletReply = future.get();

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -65,6 +65,7 @@ import com.mobiledgex.matchingengine.DmeDnsException;
 import com.mobiledgex.matchingengine.util.RequestPermissions;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -284,7 +285,7 @@ public class MainActivity extends AppCompatActivity
             io.grpc.StatusRuntimeException, DmeDnsException, PackageManager.NameNotFoundException {
         // NOTICE: In a real app, these values would be determined by the SDK, but we are reusing
         // an existing app so we don't have to create new app provisioning data for this workshop.
-        appName = "MobiledgeX SDK Demo";
+        appName = "ComputerVision";
         orgName = "MobiledgeX";
         carrierName = "TDG";
         appVersion = "2.0";
@@ -322,6 +323,14 @@ public class MainActivity extends AppCompatActivity
             return false;
         }
         Log.i(TAG, "SessionCookie:" + registerStatus.getSessionCookie());
+        try {
+            String uuid = matchingEngine.getUniqueId(this);
+            Log.i(TAG, "uuid="+uuid);
+        } catch (NoSuchAlgorithmException e) {
+            Log.e(TAG, "Can't get uuid:", e);
+            e.printStackTrace();
+        }
+
         return true;
     }
 

--- a/android/WorkshopCompleted/app/src/main/res/layout/app_bar_main.xml
+++ b/android/WorkshopCompleted/app/src/main/res/layout/app_bar_main.xml
@@ -46,7 +46,7 @@
         android:id="@+id/textViewCopyright"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved."
+        android:text="Copyright 2020 MobiledgeX, Inc. All rights and licenses reserved."
         android:textColor="#999999"
         android:textSize="12sp"
         app:layout_anchor="@+id/include"

--- a/android/WorkshopSkeleton/.idea/codeStyles/Project.xml
+++ b/android/WorkshopSkeleton/.idea/codeStyles/Project.xml
@@ -1,0 +1,116 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/android/WorkshopSkeleton/.idea/jarRepositories.xml
+++ b/android/WorkshopSkeleton/.idea/jarRepositories.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://artifactory.mobiledgex.net/maven-releases/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://artifactory.mobiledgex.net/maven-development/" />
+    </remote-repository>
+  </component>
+</project>

--- a/android/WorkshopSkeleton/app/build.gradle
+++ b/android/WorkshopSkeleton/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:15.0.1'
 
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:2.0'
+    implementation 'com.mobiledgex:matchingengine:2.1.2-hash-id'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"

--- a/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -269,7 +269,7 @@ public class MainActivity extends AppCompatActivity
             io.grpc.StatusRuntimeException, DmeDnsException, PackageManager.NameNotFoundException {
         // NOTICE: In a real app, these values would be determined by the SDK, but we are reusing
         // an existing app so we don't have to create new app provisioning data for this workshop.
-        appName = "MobiledgeX SDK Demo";
+        appName = "ComputerVision";
         orgName = "MobiledgeX";
         carrierName = "TDG";
         appVersion = "2.0";


### PR DESCRIPTION
- Change backend app name to ComputerVision.
- GPU CV activities will search for ComputerVision-GPU
- Added findCloudletGpu().
- Updated GPU-specific CV activities to include log viewer and HA testing menu items.
- Added testFindCloudletPerformance.
- App name updates for workshop apps.