### PR TITLE
EDGECLOUD-3611 Allow server to start up even with missing Redis password

### DIFF
--- a/ComputerVisionServer/REST-API.md
+++ b/ComputerVisionServer/REST-API.md
@@ -104,7 +104,7 @@ curl facedetection.defaultedge.mobiledgex.net:8008/recognizer/predict/ -F "image
 ```
 curl facedetection.defaultedge.mobiledgex.net:8008/recognizer/predict/ -F "image=@Bruce.jpg"
 <HTTP/1.1 503 Service Unavailable>
-Training data update in progress
+{"success": "false", "error": "Training data update in progress"}
 ```
 If this state is encountered, it should only last a few seconds.
 

--- a/ComputerVisionServer/moedx/static/css/style.css
+++ b/ComputerVisionServer/moedx/static/css/style.css
@@ -225,6 +225,7 @@ td {
     display: block;
   }
   #stats-wrapper {
+    min-width: 320px;    
     width: fit-content;
     bottom: 5px;
   }

--- a/ComputerVisionServer/moedx/static/js/index.js
+++ b/ComputerVisionServer/moedx/static/js/index.js
@@ -514,6 +514,12 @@ function sendImageToServer(image) {
         headers: { 'Content-Type': 'image/jpeg', 'Mobiledgex-Debug': 'true' },
         body: image
       })
+      .then(function(response) {
+        if (!response.ok) {
+          console.log(currentEndpoint + " failed. Error="+response.statusText);
+        }
+        return response;
+      })
       .then(response => response.json())
       .then(data => {
         handleResponse(data);

--- a/ComputerVisionServer/moedx/tracker/views.py
+++ b/ComputerVisionServer/moedx/tracker/views.py
@@ -194,7 +194,7 @@ def recognizer_predict(request):
     logger.debug(prepend_ip("Request received: %s" %request, request))
 
     if myFaceRecognizer.training_update_in_progress:
-        error = "Training data update in progress"
+        error = '{"success": "false", "error": "Training data update in progress"}'
         logger.error(prepend_ip("%s" %error, request))
         return HttpResponse(error, status=503)
 


### PR DESCRIPTION
- CV server will start up even if Redis password is not defined, but training data will not be (cannot be) downloaded.
- /recognizer/predict/ calls will just do face detection and respond with a subject value of "No Training Password" so the client will be notified of a configuration error.
- Made 503 error body JSON so it could be parsed by the client.