### PR TITLE
EDGECLOUD-3609 EDGECLOUD-3625 EDGECLOUD-3246 GPU hostname override, TLS support, orgName update

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'com.jfrog.artifactory'
 
 android {
     archivesBaseName = "MobiledgeXSDKDemo"
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
-        targetSdkVersion 28
-        versionCode 60
-        versionName "1.1.11"
+        targetSdkVersion 29
+        versionCode 61
+        versionName "1.1.12"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -77,7 +77,7 @@ public class Cloudlet implements Serializable {
     private SpeedTestResultsInterface mSpeedTestResultsInterface;
 
     private String mHostName;
-    private int mOpenPort = 7777;
+    private int mOpenPort = 8008;
     private final int socketTimeout = 3000;
     private boolean latencyTestTaskRunning = false;
     private boolean speedTestDownloadTaskRunning = false;

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -54,7 +54,7 @@ public class Cloudlet implements Serializable {
     private double mLatitude;
     private double mLongitude;
     private double mDistance;
-    private boolean bestMatch;
+    private boolean mBestMatch;
     private transient Marker mMarker;
 
     private double latencyMin=9999;
@@ -76,8 +76,8 @@ public class Cloudlet implements Serializable {
 
     private SpeedTestResultsInterface mSpeedTestResultsInterface;
 
-    private String hostName;
-    private int openPort = 7777;
+    private String mHostName;
+    private int mOpenPort = 7777;
     private final int socketTimeout = 3000;
     private boolean latencyTestTaskRunning = false;
     private boolean speedTestDownloadTaskRunning = false;
@@ -86,13 +86,21 @@ public class Cloudlet implements Serializable {
     private String speedTestUploadErrorMessage = "";
     private String mFqdnPrefix;
     private String mIpAddress;
-    private String fqdn;
+    private String mFqdn;
+    private String mScheme;
     private CloudletListHolder.LatencyTestMethod mLatencyTestMethod;
     private boolean mLatencyTestMethodForced = false;
 
-    public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, Marker marker, String fqdnPrefix, int port) {
+    public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, String fqdnPrefix, boolean tls, Marker marker, int port) {
         Log.d(TAG, "Cloudlet contructor. cloudletName="+cloudletName);
-        update(cloudletName, appName, carrierName, gpsLocation, distance, fqdn, marker, fqdnPrefix, port);
+        mCloudletName = cloudletName;
+        mAppName = appName;
+        mCarrierName = carrierName;
+        mLatitude = gpsLocation.latitude;
+        mLongitude = gpsLocation.longitude;
+        mDistance = distance;
+        mMarker = marker;
+        setUri(fqdnPrefix, fqdn, tls, port);
 
         if(CloudletListHolder.getSingleton().getLatencyTestAutoStart()) {
             //All AsyncTask instances are run on the same thread, so this queues up the tasks.
@@ -104,35 +112,31 @@ public class Cloudlet implements Serializable {
         mLatencyTestMethod = CloudletListHolder.getSingleton().getLatencyTestMethod();
     }
 
-    public void update(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, Marker marker, String fqdnPrefix, int port) {
-        Log.d(TAG, "Cloudlet update. cloudletName="+cloudletName);
-        mCloudletName = cloudletName;
-        mAppName = appName;
-        mCarrierName = carrierName;
-        mLatitude = gpsLocation.latitude;
-        mLongitude = gpsLocation.longitude;
-        mDistance = distance;
-        mMarker = marker;
-        setUri(fqdnPrefix, fqdn, port);
-    }
-
     /**
-     * From the given string, create the hostname that will be pinged.
+     * From the given parameters, create the hostname that will be pinged.
+     * @param fqdnPrefix
      * @param fqdn
+     * @param tls
+     * @param port
      */
-    public void setUri(String fqdnPrefix, String fqdn, int port) {
+    public void setUri(String fqdnPrefix, String fqdn, boolean tls, int port) {
         Log.i(TAG, "mCarrierName="+mCarrierName+ " setUri("+fqdnPrefix+fqdn+":"+port+")");
-        openPort = port;
+        mOpenPort = port;
         mFqdnPrefix = fqdnPrefix;
-        hostName = fqdnPrefix+fqdn;
-        this.fqdn = fqdn;
+        mHostName = fqdnPrefix+fqdn;
+        mFqdn = fqdn;
+        if (tls) {
+            mScheme = "https";
+        } else {
+            mScheme = "http";
+        }
     }
 
     public String getHostName() {
-        return hostName;
+        return mHostName;
     }
     public String getFqdn() {
-        return fqdn;
+        return mFqdn;
     }
 
     /**
@@ -141,7 +145,7 @@ public class Cloudlet implements Serializable {
      */
     private String getDownloadUri() {
         mNumBytes = CloudletListHolder.getSingleton().getNumBytesDownload();
-        return "http://"+hostName+":"+openPort+"/getdata/?numbytes="+ mNumBytes;
+        return mScheme+"://"+ mHostName +":"+ mOpenPort +"/getdata/?numbytes="+ mNumBytes;
     }
 
     /**
@@ -149,12 +153,12 @@ public class Cloudlet implements Serializable {
      * @return  The URI.
      */
     private String getUploadUri() {
-        return "http://"+hostName+":"+openPort+"/uploaddata/";
+        return mScheme+"://"+ mHostName +":"+ mOpenPort +"/uploaddata/";
     }
 
     public String toString() {
         return "mCarrierName="+mCarrierName+" mCloudletName="+mCloudletName+" mLatitude="+mLatitude
-                +" mLongitude="+mLongitude+" mDistance="+mDistance+" hostName="+hostName;
+                +" mLongitude="+mLongitude+" mDistance="+mDistance+" mScheme="+mScheme+" hostName="+ mHostName;
     }
 
     public void setSpeedTestResultsListener(SpeedTestResultsInterface speedTestResultsInterface) {
@@ -257,14 +261,14 @@ public class Cloudlet implements Serializable {
             int countSuccess = 0;
             boolean reachable;
             //First time may be slower because of DNS lookup. Run once before it counts.
-            isReachable(hostName, openPort, socketTimeout);
+            isReachable(mHostName, mOpenPort, socketTimeout);
             for(int i = 0; i < mNumPackets; i++) {
                 startTime = System.nanoTime();
-                reachable = isReachable(hostName, openPort, socketTimeout);
+                reachable = isReachable(mHostName, mOpenPort, socketTimeout);
                 if(reachable) {
                     long endTime = System.nanoTime();
                     timeDifference = (endTime - startTime)/1000000.0;
-                    Log.d(TAG, hostName+" reachable="+reachable+" Latency=" + timeDifference + " ms.");
+                    Log.d(TAG, mHostName +" reachable="+reachable+" Latency=" + timeDifference + " ms.");
                     latencyTotal += timeDifference;
                     latencyAvg = latencyTotal/(i+1);
                     if(timeDifference < latencyMin) { latencyMin = timeDifference; }
@@ -294,8 +298,8 @@ public class Cloudlet implements Serializable {
             String percent = String.format("%.1f", (countFail/(float)mNumPackets*100));
             String avg = String.format("%.3f", (latencyAvg));
             String stddev = String.format("%.3f", (latencyStddev));
-            Log.i(TAG, hostName+" "+mNumPackets+" packets transmitted, "+countSuccess+" packets received, "+percent+"% packet loss");
-            Log.i(TAG, hostName+" round-trip min/avg/max/stddev = "+latencyMin+"/"+avg+"/"+latencyMax+"/"+stddev+" ms");
+            Log.i(TAG, mHostName +" "+mNumPackets+" packets transmitted, "+countSuccess+" packets received, "+percent+"% packet loss");
+            Log.i(TAG, mHostName +" round-trip min/avg/max/stddev = "+latencyMin+"/"+avg+"/"+latencyMax+"/"+stddev+" ms");
 
             return null;
         }
@@ -325,7 +329,7 @@ public class Cloudlet implements Serializable {
         @Override
         protected String doInBackground(Void... voids) {
             pingFailed = false;
-            String pingCommand = "/system/bin/ping -c "+ mNumPackets +" " + hostName;
+            String pingCommand = "/system/bin/ping -c "+ mNumPackets +" " + mHostName;
             String inputLine = "";
 
             String regex = "time=(\\d+.\\d+) ms";
@@ -532,7 +536,7 @@ public class Cloudlet implements Serializable {
         @Override
         protected Void doInBackground(Void... params) {
             try {
-                InetAddress address = InetAddress.getByName(hostName);
+                InetAddress address = InetAddress.getByName(mHostName);
                 mIpAddress = address.getHostAddress();
                 return null;
             } catch (UnknownHostException e) {
@@ -591,9 +595,9 @@ public class Cloudlet implements Serializable {
 
     public void setMarker(Marker mMarker) { this.mMarker = mMarker; }
 
-    public boolean isBestMatch() { return bestMatch; }
+    public boolean isBestMatch() { return mBestMatch; }
 
-    public void setBestMatch(boolean bestMatch) { this.bestMatch = bestMatch; }
+    public void setBestMatch(boolean bestMatch) { this.mBestMatch = bestMatch; }
 
     public double getLatencyMin() {
         return latencyMin;

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletBuilder.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletBuilder.java
@@ -1,0 +1,71 @@
+package com.mobiledgex.sdkdemo;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
+
+public class CloudletBuilder {
+    private String cloudletName;
+    private String appName;
+    private String carrierName;
+    private LatLng gpsLocation;
+    private double distance;
+    private String fqdn;
+    private String fqdnPrefix;
+    private boolean tls;
+    private Marker marker;
+    private int port;
+
+    public CloudletBuilder setCloudletName(String cloudletName) {
+        this.cloudletName = cloudletName;
+        return this;
+    }
+
+    public CloudletBuilder setAppName(String appName) {
+        this.appName = appName;
+        return this;
+    }
+
+    public CloudletBuilder setCarrierName(String carrierName) {
+        this.carrierName = carrierName;
+        return this;
+    }
+
+    public CloudletBuilder setGpsLocation(LatLng gpsLocation) {
+        this.gpsLocation = gpsLocation;
+        return this;
+    }
+
+    public CloudletBuilder setDistance(double distance) {
+        this.distance = distance;
+        return this;
+    }
+
+    public CloudletBuilder setFqdn(String fqdn) {
+        this.fqdn = fqdn;
+        return this;
+    }
+
+    public CloudletBuilder setFqdnPrefix(String fqdnPrefix) {
+        this.fqdnPrefix = fqdnPrefix;
+        return this;
+    }
+
+    public CloudletBuilder setTls(boolean tls) {
+        this.tls = tls;
+        return this;
+    }
+
+    public CloudletBuilder setMarker(Marker marker) {
+        this.marker = marker;
+        return this;
+    }
+
+    public CloudletBuilder setPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public Cloudlet createCloudlet() {
+        return new Cloudlet(cloudletName, appName, carrierName, gpsLocation, distance, fqdn, fqdnPrefix, tls, marker, port);
+    }
+}

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <string name="app_name">MobiledgeX SDK Demo</string>
     <string name="dme_app_name">ComputerVision</string>
-    <string name="app_version">2.0</string>
-    <string name="org_name">MobiledgeX</string>
+    <string name="app_version">2.2</string>
+    <string name="org_name">MobiledgeX-Samples</string>
 
     <string name="yes">Yes</string>
     <string name="no">No</string>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -1312,11 +1312,13 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             fqdnPrefix = aPort.getFqdnPrefix();
             mTls = aPort.getTls();
             Log.i(TAG, "Setting TLS="+mTls);
-
         }
         // Build full hostname.
 //        mHostDetectionEdge = fqdnPrefix+mClosestCloudlet.getFqdn();
-        mHostDetectionEdge = mClosestCloudlet.getFqdn(); // TODO: Revert this to prepend fqdnPrefix after EDGECLOUD-3634 is fixed.
+        // TODO: Revert this to prepend fqdnPrefix after EDGECLOUD-3634 is fixed.
+        // Note that Docker deployments don't even have FqdnPrefix, so this workaround
+        // is only needed for k8s, but the same code will work for both.
+        mHostDetectionEdge = mClosestCloudlet.getFqdn();
         mEdgeHostList.clear();
         mEdgeHostListIndex = 0;
         mEdgeHostList.add(mHostDetectionEdge);
@@ -1359,15 +1361,19 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
                 //Find fqdnPrefix from Port structure.
                 String fqdnPrefix = "";
                 List<Appcommon.AppPort> ports = appInst.getPortsList();
-                for (Appcommon.AppPort aPort : ports) {
-                    // Get data only from first port.
-                    if (fqdnPrefix.equals("")) {
-                        fqdnPrefix = aPort.getFqdnPrefix();
-                        mTls = aPort.getTls();
-                    }
+                // Get data only from first port.
+                Appcommon.AppPort aPort = ports.get(0);
+                if (aPort != null) {
+                    Log.i(TAG, "Got port "+aPort+" TLS="+aPort.getTls()+" fqdnPrefix="+fqdnPrefix);
+                    fqdnPrefix = aPort.getFqdnPrefix();
+                    mTls = aPort.getTls();
+                    Log.i(TAG, "Setting TLS="+mTls);
                 }
 //                String hostname = fqdnPrefix + appInst.getFqdn();
-                String hostname = appInst.getFqdn(); // TODO: Revert this to prepend fqdnPrefix after EDGECLOUD-3634 is fixed.
+                // TODO: Revert this to prepend fqdnPrefix after EDGECLOUD-3634 is fixed.
+                // Note that Docker deployments don't even have FqdnPrefix, so this workaround
+                // is only needed for k8s, but the same code will work for both.
+                String hostname = appInst.getFqdn();
                 mEdgeHostList.add(hostname);
                 showMessage("Found " + hostname);
             }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -233,13 +233,17 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             RollingAverage ra = new RollingAverage(CloudletType.EDGE, "Error", 1);
             updateFullProcessStats(CloudletType.EDGE, ra);
             updateNetworkStats(CloudletType.EDGE, ra);
-            if (prefAutoFailover || text.equals("Manual Failover")) {
+            boolean manualFailover = text.equals("Manual Failover");
+            if (prefAutoFailover || manualFailover) {
                 Log.i(TAG, "Restarting mImageSenderEdge due to reportConnectionError: "+text);
                 mEdgeHostListIndex++;
                 if (mEdgeHostList.size() > mEdgeHostListIndex) {
                     mHostDetectionEdge = mEdgeHostList.get(mEdgeHostListIndex);
                     restartImageSenderEdge();
                 } else {
+                    if (mEdgeHostList.size() > 1) {
+                        showMessage("Host list exhausted.");
+                    }
                     findCloudletInBackground();
                 }
             } else {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -178,7 +178,6 @@ public class ImageSender {
         public ImageSender build() {
             return new ImageSender(this);
         }
-
     }
 
     private ImageSender(final Builder builder) {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -65,6 +65,8 @@ public class ImageSender {
     private ImageServerInterface mImageServerInterface;
     private RequestQueue mRequestQueue;
 
+    private boolean mTls;
+    private String mScheme;
     private String mHost;
     private int mPort;
     private int mPersistentTcpPort;
@@ -127,6 +129,7 @@ public class ImageSender {
         private Activity activity;
         private ImageServerInterface imageServerInterface;
         private ImageServerInterface.CloudletType cloudLetType;
+        private boolean tls;
         private String host;
         private int port;
         private int persistentTcpPort;
@@ -144,6 +147,11 @@ public class ImageSender {
 
         public Builder setCloudLetType(ImageServerInterface.CloudletType cloudLetType) {
             this.cloudLetType = cloudLetType;
+            return this;
+        }
+
+        public Builder setTls(boolean tls) {
+            this.tls = tls;
             return this;
         }
 
@@ -170,10 +178,12 @@ public class ImageSender {
         public ImageSender build() {
             return new ImageSender(this);
         }
+
     }
 
     private ImageSender(final Builder builder) {
         mCloudLetType = builder.cloudLetType;
+        mTls = builder.tls;
         mHost = builder.host;
         mPort = builder.port;
         mPersistentTcpPort = builder.persistentTcpPort;
@@ -278,7 +288,9 @@ public class ImageSender {
             Log.i(TAG, mCloudLetType+" can't start WebSocket client with null host");
             return;
         }
-        String url = "ws://"+mHost+":"+mPort+"/ws"+mDjangoUrl;
+
+        mScheme =  mTls ? "ws" : "wss";
+        String url = mScheme+"://"+mHost+":"+mPort+"/ws"+mDjangoUrl;
         Log.i(TAG, mCloudLetType+" attempting to start WebSocket client. url: " + url);
         okhttp3.Request request = new okhttp3.Request.Builder().url(url).build();
         ResultWebSocketListener listener = new ResultWebSocketListener();
@@ -358,11 +370,6 @@ public class ImageSender {
             mDjangoUrl = "/object/detect/";
         } else {
             Log.e(TAG, "Invalid CameraMode: "+mode);
-        }
-        try {
-            throw new Exception("Null cameramode");
-        } catch (Exception e) {
-            e.printStackTrace();
         }
         Log.i(TAG, "setCameraMode("+mCameraMode+") mOpcode="+mOpcode+" mDjangoUrl="+ mDjangoUrl +" "+mCloudLetType+" host="+mHost);
     }
@@ -446,7 +453,8 @@ public class ImageSender {
 
         } else if(mConnectionMode == ConnectionMode.REST) {
             final String requestBody = Base64.encodeToString(bytes, Base64.DEFAULT);
-            String url = "http://"+ mHost +":"+mPort + mDjangoUrl;
+            mScheme =  mTls ? "https" : "http";
+            String url = mScheme+"://"+ mHost +":"+mPort + mDjangoUrl;
             Log.i(TAG, "url="+url+" length: "+requestBody.length());
 
             // Request a byte response from the provided URL.
@@ -551,7 +559,8 @@ public class ImageSender {
         Log.i(TAG, mCloudLetType +" trainerTrain mCameraMode="+mCameraMode);
         setCameraMode(CameraMode.FACE_UPDATING_SERVER);
 
-        String url = "http://"+ mHost +":"+mPort+"/trainer/train/";
+        mScheme =  mTls ? "https" : "http";
+        String url = mScheme+"://"+ mHost +":"+mPort+"/trainer/train/";
         Log.i(TAG, mCloudLetType +" url="+url);
 
         final long startTime = System.nanoTime();
@@ -593,7 +602,8 @@ public class ImageSender {
      * Sends request to the FaceTrainingServer to remove training data.
      */
     public void trainerRemove() {
-        String url = "http://"+ mHost +":"+mPort+"/trainer/remove/";
+        mScheme =  mTls ? "https" : "http";
+        String url = mScheme+"://"+ mHost +":"+mPort+"/trainer/remove/";
         Log.i(TAG, mCloudLetType +" url="+url);
         setCameraMode(CameraMode.FACE_UPDATING_SERVER);
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectClassRenderer.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectClassRenderer.java
@@ -89,7 +89,7 @@ public class ObjectClassRenderer extends View {
             paint.setStyle(Paint.Style.STROKE);
             mPaints.add(paint);
             Paint fillPaint = new Paint(paint);
-            fillPaint.setAlpha(96);
+            fillPaint.setAlpha(96); // out of 255
             fillPaint.setStyle(Paint.Style.FILL);
             mFillPaints.add(fillPaint);
         }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -249,7 +249,15 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
 
         mVideoFilename = VIDEO_FILE_NAME;
 
-        findCloudletGpuInBackground();
+        if (mGpuHostNameOverride) {
+            mEdgeHostList.clear();
+            mEdgeHostListIndex = 0;
+            mEdgeHostList.add(mHostDetectionEdge);
+            showMessage("Overriding GPU host. Host=" + mHostDetectionEdge);
+            restartImageSenderEdge();
+        } else {
+            findCloudletGpuInBackground();
+        }
     }
 
     @Override
@@ -298,6 +306,42 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
         } else {
             mStdFull.setVisibility(View.GONE);
             mStdNet.setVisibility(View.GONE);
+        }
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        Log.i(TAG, "Pose Detection onSharedPreferenceChanged("+key+")");
+        if(getContext() == null) {
+            //Can happen during rapid screen rotations.
+            return;
+        }
+        super.onSharedPreferenceChanged(sharedPreferences, key);
+
+        String prefKeyHostGpuOverride = getResources().getString(R.string.pref_override_gpu_cloudlet_hostname);
+        String prefKeyHostGpu = getResources().getString(R.string.preference_openpose_host_edge);
+
+        if (key.equals(prefKeyHostGpuOverride) || key.equals("ALL")) {
+            mGpuHostNameOverride = sharedPreferences.getBoolean(prefKeyHostGpuOverride, false);
+            Log.i(TAG, "key="+key+" mGpuHostNameOverride="+ mGpuHostNameOverride);
+            if (mGpuHostNameOverride) {
+                mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+                Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
+            }
+        }
+        if (key.equals(prefKeyHostGpu) || key.equals("ALL")) {
+            mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+            Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
+        }
+
+        if (key.equals(prefKeyHostGpu) || key.equals(prefKeyHostGpuOverride)) {
+            if (mGpuHostNameOverride) {
+                mEdgeHostList.clear();
+                mEdgeHostListIndex = 0;
+                mEdgeHostList.add(mHostDetectionEdge);
+                showMessage("mHostDetectionEdge set to " + mHostDetectionEdge);
+                restartImageSenderEdge();
+            }
         }
     }
 }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="dme_app_name">ComputerVision</string>
-    <string name="app_version">2.0</string>
-    <string name="org_name">MobiledgeX</string>
+    <string name="app_version">2.2</string>
+    <string name="org_name">MobiledgeX-Samples</string>
 
     <string name="title_activity_face_detection">Face Detection</string>
     <string name="title_activity_face_recognition">Face Recognition</string>
@@ -100,5 +100,9 @@
         <item>PERSISTENT_TCP</item>
         <item>WEBSOCKET</item>
     </string-array>
+
+    <string name="pref_override_gpu_cloudlet_hostname">pref_override_gpu_cloudlet_hostname</string>
+    <string name="pref_summary_override_gpu_cloudlet_hostname">Select this to enter a GPU hostname to override the FindCloudlet result.</string>
+    <string name="pref_title_override_gpu_cloudlet_hostname">Override GPU cloudlet hostname</string>
 
 </resources>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
@@ -83,7 +83,13 @@
         android:singleLine="false"
         android:summary="@string/preference_fd_host_edge_summary"
         android:title="@string/preference_fd_host_edge_title" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/pref_override_gpu_cloudlet_hostname"
+        android:summary="@string/pref_summary_override_gpu_cloudlet_hostname"
+        android:title="@string/pref_title_override_gpu_cloudlet_hostname" />
     <EditTextPreference
+        android:dependency="@string/pref_override_gpu_cloudlet_hostname"
         android:defaultValue="posedetection.defaultedge.mobiledgex.net"
         android:key="@string/preference_openpose_host_edge"
         android:selectAllOnFocus="true"


### PR DESCRIPTION
- Builder support for Cloudlet class, standardized some member variable names.
- Custom hostname can be used for GPU CV activities if the override preference is enabled. 
- TLS support for speedtest and CV image sending, both https and wss.
- Bug fixes for GPU HA support.