### PR TITLE
EDGECLOUD-3671 Use provisioning data instead of default hostnames

### DIFF
--- a/android/MobiledgeXSDKDemo/README.md
+++ b/android/MobiledgeXSDKDemo/README.md
@@ -67,11 +67,11 @@ Things to try:
 - Go to settings and turn on "Show Latency Stats after session" to get a stats summary that can be copy/pasted for additional use.
 
 #### Face Detection
-The Face Detection activity provides a visual comparison of the latency offered by an Edge cloudlet vs. that of a server in the public cloud. The Edge cloudlet can be determined in a few ways, in this order of priorit: 
+The Face Detection activity provides a visual comparison of the latency offered by an Edge cloudlet vs. that of a server in the public cloud. The Edge cloudlet can be determined in a few ways, in this order of priority:
 1. The result of "Find Closest Cloudlet", if performed.
-1. Selected from within the Cloudlet Details page.
+1. Selected from within the Cloudlet Details page options menu. This also activates the "Override Edge cloudlet hostname" value in **Computer Vision Settings**.
 1. "Edge Server" entry in the **Computer Vision Settings**, if updated by the user.
-1. The default hostname: facedetection.defaultedge.mobiledgex.net.
+1. The default hostname from the provisioning data at http://opencv.facetraining.mobiledgex.net/cvprovisioning.json.
 
 Images from the camera are sent to a server that uses OpenCV to detect faces in the image. The server returns coordinates of any faces, and the app renders rectangles around them. 
 

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -143,16 +143,20 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
         if (id == R.id.action_copy_cloud_host) {
             String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
+            String prefKeyHostCloudOverride = getResources().getString(R.string.pref_override_cloud_cloudlet_hostname);
             String hostname = cloudlet.getHostName();
             Log.i(TAG, "Cloud hostname being set to: "+hostname);
             prefs.edit().putString(prefKeyHostCloud, hostname).apply();
+            prefs.edit().putBoolean(prefKeyHostCloudOverride, true).apply();
             return true;
         }
         if (id == R.id.action_copy_edge_host) {
             String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
+            String prefKeyHostEdgeOverride = getResources().getString(R.string.pref_override_edge_cloudlet_hostname);
             String hostname = cloudlet.getHostName();
             Log.i(TAG, "Edge hostname being set to: "+hostname);
             prefs.edit().putString(prefKeyHostEdge, hostname).apply();
+            prefs.edit().putBoolean(prefKeyHostEdgeOverride, true).apply();
             return true;
         }
         if (id == R.id.action_speedtest_settings) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -1319,10 +1319,6 @@ public class MainActivity extends AppCompatActivity
         String prefKeyDefaultOperatorName = getResources().getString(R.string.pref_default_operator_name);
         String prefKeyFindCloudletMode = getResources().getString(R.string.pref_find_cloudlet_mode);
         String prefKeyAppInstancesLimit = getResources().getString(R.string.pref_app_instances_limit);
-        String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
-        String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
-        String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
-        String prefKeyResetFdHosts = getResources().getString(R.string.preference_fd_reset_both_hosts);
         String prefKeyDefaultAppInfo = getResources().getString(R.string.pref_default_app_definition);
         String prefKeyAppName = getResources().getString(R.string.pref_app_name);
         String prefKeyAppVersion = getResources().getString(R.string.pref_app_version);
@@ -1492,36 +1488,6 @@ public class MainActivity extends AppCompatActivity
             CloudletListHolder.getSingleton().setNumPackets(numPackets);
         }
 
-        if(key.equals(prefKeyHostCloud)) {
-            // This call will attempt to connect to the server at prefKeyHostCloud.
-            // If it fails, the default will be restored.
-            new FaceServerConnectivityTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                    ImageProcessorFragment.DEF_FACE_HOST_CLOUD, key);
-        }
-        if(key.equals(prefKeyHostEdge)) {
-            // This call will attempt to connect to the server at prefKeyHostEdge.
-            // If it fails, the default will be restored.
-            mClosestCloudletHostname = null;
-            new FaceServerConnectivityTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                    ImageProcessorFragment.DEF_FACE_HOST_EDGE, key);
-        }
-
-        if(key.equals(prefKeyResetFdHosts)) {
-            String value = sharedPreferences.getString(prefKeyResetFdHosts, "No");
-            mClosestCloudletHostname = null;
-            Log.i(TAG, prefKeyResetFdHosts+" "+value);
-            if(value.startsWith("Yes")) {
-                Log.i(TAG, "Resetting Face server hosts.");
-                sharedPreferences.edit().putString(prefKeyHostCloud, ImageProcessorFragment.DEF_FACE_HOST_CLOUD).apply();
-                sharedPreferences.edit().putString(prefKeyHostEdge, ImageProcessorFragment.DEF_FACE_HOST_EDGE).apply();
-                sharedPreferences.edit().putString(prefKeyOpenPoseHostEdge, PoseProcessorFragment.DEF_OPENPOSE_HOST_EDGE).apply();
-                Toast.makeText(this, "Face detection hosts reset to default.", Toast.LENGTH_SHORT).show();
-            }
-            //Always set the value back to something so that either clicking Yes or No in the dialog
-            //will activate this "changed" call.
-            sharedPreferences.edit().putString(prefKeyResetFdHosts, "XXX_garbage_value").apply();
-        }
-
         if (appInfoChanged) {
             getCloudlets(true);
         }
@@ -1557,45 +1523,6 @@ public class MainActivity extends AppCompatActivity
             String message = "Invalid DME hostname and port: "+hostAndPort;
             throw new HostParseException(message);
         }
-    }
-
-    private class FaceServerConnectivityTask extends AsyncTask<String, Void, Boolean> {
-        private String newHost;
-
-        @Override
-        protected Boolean doInBackground(String... params) {
-            String defaultHost = params[0];
-            String keyName = params[1];
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
-            newHost = prefs.getString(keyName, defaultHost);
-            boolean reachable = ImageSender.isReachable(newHost,
-                    ImageSender.getComputerVisionServerPort(newHost), 3000);
-            if(!reachable) {
-                Log.e(TAG, newHost+" not reachable. Resetting "+keyName+" to default.");
-                prefs.edit().putString(keyName, defaultHost).apply();
-                return false;
-            }
-            return true;
-        }
-        @Override
-        protected void onPostExecute(Boolean result) {
-            String message;
-            if(result) {
-                message = "Verified new host: "+newHost;
-                Log.i(TAG, message);
-            } else {
-                message = "Could not reach face server at '"+newHost+"'. Resetting to default.";
-            }
-            if (newHost.equals(ImageProcessorFragment.DEF_FACE_HOST_CLOUD) || newHost.equals(ImageProcessorFragment.DEF_FACE_HOST_EDGE)) {
-                // Don't show Toast for defaults.
-            } else {
-                Toast.makeText(MainActivity.this, message, Toast.LENGTH_LONG).show();
-            }
-        }
-        @Override
-        protected void onPreExecute() {}
-        @Override
-        protected void onProgressUpdate(Void... values) {}
     }
 
     @Override

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
@@ -183,7 +183,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         return PreferenceFragment.class.getName().equals(fragmentName)
                 || MatchingEngineSettingsFragment.class.getName().equals(fragmentName)
                 || GeneralSettingsFragment.class.getName().equals(fragmentName)
-                || FaceDetectionSettingsFragment.class.getName().equals(fragmentName)
+                || com.mobiledgex.computervision.SettingsActivity.FaceDetectionSettingsFragment.class.getName().equals(fragmentName)
                 || SpeedTestSettingsFragment.class.getName().equals(fragmentName);
     }
 
@@ -397,41 +397,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             region = dmeListPref.getValue();
         }
         return region;
-    }
-
-    // Face Detection Preferences.
-    public static class FaceDetectionSettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
-        @Override
-        public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            addPreferencesFromResource(R.xml.pref_face_detection);
-            setHasOptionsMenu(true);
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
-            prefs.registerOnSharedPreferenceChangeListener(this);
-        }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                startActivity(new Intent(getActivity(), SettingsActivity.class));
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
-        }
-
-        @Override
-        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            // Reinitialize this screen of preferences, since values may have changed.
-            // If an NPE occurs because the PreferenceManager has gone away,
-            // there's no need for any action. Just don't crash the app.
-            try {
-                getPreferenceScreen().removeAll();
-                addPreferencesFromResource(R.xml.pref_face_detection);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
     }
 
     // TODO: Implement this

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/SettingsActivity.java
@@ -408,14 +408,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             setHasOptionsMenu(true);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             prefs.registerOnSharedPreferenceChangeListener(this);
-
-            String prefKeyHostCloud = getResources().getString(com.mobiledgex.computervision.R.string.preference_fd_host_cloud);
-            String prefKeyHostEdge = getResources().getString(com.mobiledgex.computervision.R.string.preference_fd_host_edge);
-            String prefKeyOpenPoseHostEdge = getResources().getString(com.mobiledgex.computervision.R.string.preference_openpose_host_edge);
-
-            bindPreferenceSummaryToValue(findPreference(prefKeyHostCloud));
-            bindPreferenceSummaryToValue(findPreference(prefKeyHostEdge));
-            bindPreferenceSummaryToValue(findPreference(prefKeyOpenPoseHostEdge));
         }
 
         @Override

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_headers.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_headers.xml
@@ -13,7 +13,7 @@
         android:icon="@android:drawable/ic_menu_recent_history"
         android:title="@string/preference_speed_test_settings"/>
     <header
-        android:fragment="com.mobiledgex.sdkdemo.SettingsActivity$FaceDetectionSettingsFragment"
+        android:fragment="com.mobiledgex.computervision.SettingsActivity$FaceDetectionSettingsFragment"
         android:icon="@android:drawable/ic_menu_camera"
         android:title="@string/preference_fd_settings"/>
 

--- a/android/MobiledgeXSDKDemo/computervision/src/androidTest/java/com/mobiledgex/computervision/ComputerVisionRestUnitTest.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/androidTest/java/com/mobiledgex/computervision/ComputerVisionRestUnitTest.java
@@ -358,7 +358,7 @@ public class ComputerVisionRestUnitTest {
     public void test001OpenposeDetectEndpoint() {
         Context ctx = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        String url = "https://posedetection.defaultedge.mobiledgex.net:8008";
+        String url = "https://cv-gpu-cluster.hamburg-main.tdg.mobiledgex.net:8008";
 
         String detectorDetectEndpoint = "/openpose/detect/";
         url += detectorDetectEndpoint;
@@ -380,7 +380,7 @@ public class ComputerVisionRestUnitTest {
     public void test001ObjectDetectEndpoint() {
         Context ctx = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        String url = "https://posedetection.defaultedge.mobiledgex.net:8008";
+        String url = "https://cv-gpu-cluster.hamburg-main.tdg.mobiledgex.net:8008";
 
         String detectorDetectEndpoint = "/object/detect/";
         url += detectorDetectEndpoint;

--- a/android/MobiledgeXSDKDemo/computervision/src/main/assets/cvprovisioning.json
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/assets/cvprovisioning.json
@@ -1,0 +1,21 @@
+{
+  "product": "ComputerVision Provisioning Data",
+  "releaseDate": "2020-09-25",
+  "comment": "This device-local copy will only be used if the online version isn't available or fails to parse.",
+  "regions": {
+    "default": {
+      "defaultHostNames": {
+        "edge": "cv-cluster.berlin-main.tdg.mobiledgex.net",
+        "cloud": "computervision-tcp.mobiledgex-samplescomputervision22.cv-cluster.us-los-angeles.gcp.mobiledgex.net",
+        "gpu": "cv-gpu-cluster.hamburg-main.tdg.mobiledgex.net"
+      }
+    },
+    "us-mexdemo.dme.mobiledgex.net": {
+      "defaultHostNames": {
+        "edge": "computervision-tcp.mobiledgex-samplescomputervision22.cv-cluster.us-los-angeles.gcp.mobiledgex.net",
+        "cloud": "cv-cluster.berlin-main.tdg.mobiledgex.net",
+        "gpu": "cv-gpu-cluster.hamburg-main.tdg.mobiledgex.net"
+      }
+    }
+  }
+}

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -293,10 +293,10 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
         }
         String message;
         if (mImageSenderEdge == null) {
-            message = "Starting mImageSenderEdge on host: " + mHostDetectionEdge;
+            message = "Starting " + mCameraToolbar.getTitle() + " on EDGE host " + mHostDetectionEdge;
             initialLogsComplete();
         } else {
-            message = "Restarting mImageSenderEdge on host: " + mHostDetectionEdge;
+            message = "Restarting " + mCameraToolbar.getTitle() + " on EDGE host " + mHostDetectionEdge;
             mImageSenderEdge.closeConnection();
         }
         Log.i(TAG, message);
@@ -813,28 +813,11 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
         String prefKeyUseRollingAvg = getResources().getString(R.string.preference_fd_use_rolling_avg);
         String prefKeyAutoFailover = getResources().getString(R.string.preference_fd_auto_failover);
         String prefKeyShowCloudOutput = getResources().getString(R.string.preference_fd_show_cloud_output);
-        String prefKeyResetCvHosts = getResources().getString(R.string.preference_fd_reset_all_hosts);
         String prefKeyHostCloudOverride = getResources().getString(R.string.pref_override_cloud_cloudlet_hostname);
         String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
         String prefKeyHostEdgeOverride = getResources().getString(R.string.pref_override_edge_cloudlet_hostname);
         String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
-        String prefKeyHostGpu = getResources().getString(R.string.preference_gpu_host_edge);
         String prefKeyHostTraining = getResources().getString(R.string.preference_fd_host_training);
-
-        if(key.equals(prefKeyResetCvHosts)) {
-            String value = sharedPreferences.getString(prefKeyResetCvHosts, "No");
-            Log.i(TAG, prefKeyResetCvHosts+" "+value);
-            if(value.startsWith("Yes")) {
-                Log.i(TAG, "Resetting Face server hosts.");
-                sharedPreferences.edit().putString(prefKeyHostCloud, DEF_HOSTNAME_PLACEHOLDER).apply();
-                sharedPreferences.edit().putString(prefKeyHostEdge, DEF_HOSTNAME_PLACEHOLDER).apply();
-                sharedPreferences.edit().putString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER).apply();
-                Toast.makeText(getContext(), "Computer Vision hosts reset to default.", Toast.LENGTH_SHORT).show();
-            }
-            //Always set the value back to something so that either clicking Yes or No in the dialog
-            //will activate this "changed" call.
-            sharedPreferences.edit().putString(prefKeyResetCvHosts, "XXX_garbage_value").apply();
-        }
 
         // Cloud Hostname handling
         if (key.equals(prefKeyHostCloudOverride) || key.equals("ALL")) {
@@ -1156,6 +1139,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
                 .setPersistentTcpPort(PERSISTENT_TCP_PORT)
                 .setCameraMode(mCameraMode)
                 .build();
+        showMessage("Starting " + mCameraToolbar.getTitle() + " on CLOUD host " + mHostDetectionCloud);
 
         if (mEdgeHostNameOverride) {
             mHostDetectionEdge = mHostDetectionEdge.toLowerCase();
@@ -1170,7 +1154,7 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
             mEdgeHostList.clear();
             mEdgeHostListIndex = 0;
             mEdgeHostList.add(mHostDetectionEdge);
-            showMessage("Overriding GPU host. Host=" + mHostDetectionEdge);
+            showMessage("Overriding Edge host. Host=" + mHostDetectionEdge);
             restartImageSenderEdge();
         } else {
             findCloudletInBackground();
@@ -1184,10 +1168,6 @@ public class ImageProcessorFragment extends Fragment implements ImageServerInter
                 .setPort(FACE_TRAINING_HOST_PORT)
                 .setPersistentTcpPort(PERSISTENT_TCP_PORT)
                 .build();
-
-        showMessage("Starting " + mCameraToolbar.getTitle() + " on CLOUD host " + mHostDetectionCloud);
-        showMessage("Starting " + mCameraToolbar.getTitle() + " on EDGE host " + mHostDetectionEdge);
-        initialLogsComplete();
 
         mVideoFilename = VIDEO_FILE_NAME;
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -129,7 +129,7 @@ public class ImageSender {
         private Activity activity;
         private ImageServerInterface imageServerInterface;
         private ImageServerInterface.CloudletType cloudLetType;
-        private boolean tls;
+        private boolean tls = false;
         private String host;
         private int port;
         private int persistentTcpPort;
@@ -189,6 +189,8 @@ public class ImageSender {
         setCameraMode(builder.cameraMode);
 
         mImageServerInterface = builder.imageServerInterface;
+
+        Log.i(TAG, "ImageSender "+mCloudLetType+" "+mHost+":"+mPort+" mTls="+mTls+" mCameraMode="+mCameraMode);
 
         try {
             mAccount = GoogleSignIn.getLastSignedInAccount(builder.activity);
@@ -270,7 +272,7 @@ public class ImageSender {
         }
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, okhttp3.Response response) {
-            String message = "WebSocket Error: " + t.getMessage();
+            String message = mCloudLetType + " WebSocket Error: " + t.getMessage();
             Log.e(TAG, message);
             mWebSocketClient.dispatcher().cancelAll();
             if (response != null && response.code() == 404) {
@@ -288,7 +290,7 @@ public class ImageSender {
             return;
         }
 
-        mScheme =  mTls ? "ws" : "wss";
+        mScheme =  mTls ? "wss" : "ws";
         String url = mScheme+"://"+mHost+":"+mPort+"/ws"+mDjangoUrl;
         Log.i(TAG, mCloudLetType+" attempting to start WebSocket client. url: " + url);
         okhttp3.Request request = new okhttp3.Request.Builder().url(url).build();
@@ -412,7 +414,7 @@ public class ImageSender {
      * @param bitmap  The image to encode and send.
      */
     public void sendImage(Bitmap bitmap) {
-        Log.d(TAG, "sendImage()");
+        Log.d(TAG, mCloudLetType+"sendImage()");
         if(mBusy || mInactive || mInactiveBenchmark || mInactiveFailure) {
             return;
         }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -42,8 +42,6 @@ import org.json.JSONArray;
 
 import java.text.DecimalFormat;
 
-import static com.mobiledgex.computervision.PoseProcessorFragment.DEF_OPENPOSE_HOST_EDGE;
-
 public class ObjectProcessorFragment extends ImageProcessorFragment implements ImageServerInterface,
         ImageProviderInterface {
     private static final String TAG = "ObjectProcessorFragment";
@@ -54,8 +52,6 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
     private TextView mLatencyNet;
     private TextView mStdFull;
     private TextView mStdNet;
-
-    public static final String DEF_OBJECT_DETECTION_HOST_EDGE = "posedetection.defaultedge.mobiledgex.net";
 
     public static ObjectProcessorFragment newInstance() {
         return new ObjectProcessorFragment();
@@ -232,11 +228,6 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
         prefs.registerOnSharedPreferenceChangeListener(this);
         onSharedPreferenceChanged(prefs, "ALL");
 
-        // TODO: Create separate preference for Object Detection Host
-        String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
-        mHostDetectionEdge = prefs.getString(prefKeyOpenPoseHostEdge, DEF_OBJECT_DETECTION_HOST_EDGE);
-        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
-
         Intent intent = getActivity().getIntent();
         getCommonIntentExtras(intent);
 
@@ -316,18 +307,18 @@ public class ObjectProcessorFragment extends ImageProcessorFragment implements I
         super.onSharedPreferenceChanged(sharedPreferences, key);
 
         String prefKeyHostGpuOverride = getResources().getString(R.string.pref_override_gpu_cloudlet_hostname);
-        String prefKeyHostGpu = getResources().getString(R.string.preference_openpose_host_edge);
+        String prefKeyHostGpu = getResources().getString(R.string.preference_gpu_host_edge);
 
         if (key.equals(prefKeyHostGpuOverride) || key.equals("ALL")) {
             mGpuHostNameOverride = sharedPreferences.getBoolean(prefKeyHostGpuOverride, false);
             Log.i(TAG, "key="+key+" mGpuHostNameOverride="+ mGpuHostNameOverride);
             if (mGpuHostNameOverride) {
-                mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+                mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER);
                 Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
             }
         }
         if (key.equals(prefKeyHostGpu) || key.equals("ALL")) {
-            mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+            mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
         }
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -55,8 +55,6 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
     private TextView mStdFull;
     private TextView mStdNet;
 
-    public static final String DEF_OPENPOSE_HOST_EDGE = "posedetection.defaultedge.mobiledgex.net";
-
     public static PoseProcessorFragment newInstance() {
         return new PoseProcessorFragment();
     }
@@ -232,10 +230,6 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
         prefs.registerOnSharedPreferenceChangeListener(this);
         onSharedPreferenceChanged(prefs, "ALL");
 
-        String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
-        mHostDetectionEdge = prefs.getString(prefKeyOpenPoseHostEdge, DEF_OPENPOSE_HOST_EDGE);
-        Log.i(TAG, "prefKeyOpenPoseHostEdge="+prefKeyOpenPoseHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
-
         Intent intent = getActivity().getIntent();
         getCommonIntentExtras(intent);
 
@@ -320,18 +314,18 @@ public class PoseProcessorFragment extends ImageProcessorFragment implements Ima
         super.onSharedPreferenceChanged(sharedPreferences, key);
 
         String prefKeyHostGpuOverride = getResources().getString(R.string.pref_override_gpu_cloudlet_hostname);
-        String prefKeyHostGpu = getResources().getString(R.string.preference_openpose_host_edge);
+        String prefKeyHostGpu = getResources().getString(R.string.preference_gpu_host_edge);
 
         if (key.equals(prefKeyHostGpuOverride) || key.equals("ALL")) {
             mGpuHostNameOverride = sharedPreferences.getBoolean(prefKeyHostGpuOverride, false);
             Log.i(TAG, "key="+key+" mGpuHostNameOverride="+ mGpuHostNameOverride);
             if (mGpuHostNameOverride) {
-                mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+                mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER);
                 Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
             }
         }
         if (key.equals(prefKeyHostGpu) || key.equals("ALL")) {
-            mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_OPENPOSE_HOST_EDGE);
+            mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
         }
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseRenderer.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseRenderer.java
@@ -37,8 +37,8 @@ import java.util.List;
  */
 public class PoseRenderer extends View {
     private static final String TAG = "PoseRenderer";
-    public static final int DEFAULT_JOINT_RADIUS = 18;
-    public static final int DEFAULT_STROKE_WIDTH = 15;
+    public static final int DEFAULT_JOINT_RADIUS = 14;
+    public static final int DEFAULT_STROKE_WIDTH = 10;
     private int mJointRadius = DEFAULT_JOINT_RADIUS;
     private int mStrokeWidth = DEFAULT_STROKE_WIDTH;
     private JSONArray mPoses;

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
@@ -33,8 +33,11 @@ import androidx.appcompat.app.ActionBar;
 
 import android.util.Log;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import java.util.List;
+
+import static com.mobiledgex.computervision.ImageProcessorFragment.DEF_HOSTNAME_PLACEHOLDER;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -170,6 +173,15 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
     // Face Detection Preferences.
     public static class FaceDetectionSettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+        private String prefKeyResetCvHosts;
+        private String prefKeyHostCloudOverride;
+        private String prefKeyHostCloud;
+        private String prefKeyHostEdgeOverride;
+        private String prefKeyHostEdge;
+        private String prefKeyHostGpuOverride;
+        private String prefKeyHostGpu;
+
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
@@ -178,13 +190,17 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             prefs.registerOnSharedPreferenceChangeListener(this);
 
-            String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
-            String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
-            String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_gpu_host_edge);
+            prefKeyResetCvHosts = getResources().getString(R.string.preference_fd_reset_all_hosts);
+            prefKeyHostCloudOverride = getResources().getString(R.string.pref_override_cloud_cloudlet_hostname);
+            prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
+            prefKeyHostEdgeOverride = getResources().getString(R.string.pref_override_edge_cloudlet_hostname);
+            prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
+            prefKeyHostGpuOverride = getResources().getString(R.string.pref_override_gpu_cloudlet_hostname);
+            prefKeyHostGpu = getResources().getString(R.string.preference_gpu_host_edge);
 
             bindPreferenceSummaryToValue(findPreference(prefKeyHostCloud));
             bindPreferenceSummaryToValue(findPreference(prefKeyHostEdge));
-            bindPreferenceSummaryToValue(findPreference(prefKeyOpenPoseHostEdge));
+            bindPreferenceSummaryToValue(findPreference(prefKeyHostGpu));
         }
 
         @Override
@@ -199,14 +215,34 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            // Reinitialize this screen of preferences, since values may have changed.
-            // If an NPE occurs because the PreferenceManager has gone away,
-            // there's no need for any action. Just don't crash the app.
-            try {
-                getPreferenceScreen().removeAll();
-                addPreferencesFromResource(R.xml.pref_face_detection);
-            } catch (Exception e) {
-                e.printStackTrace();
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")");
+
+            if(key.equals(prefKeyResetCvHosts)) {
+                String value = sharedPreferences.getString(prefKeyResetCvHosts, "No");
+                Log.i(TAG, prefKeyResetCvHosts+" "+value);
+                if(value.startsWith("Yes")) {
+                    Log.i(TAG, "Resetting Computer Vision server hosts.");
+                    sharedPreferences.edit().putString(prefKeyHostCloud, DEF_HOSTNAME_PLACEHOLDER)
+                        .putString(prefKeyHostEdge, DEF_HOSTNAME_PLACEHOLDER)
+                        .putString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER)
+                        .putBoolean(prefKeyHostCloudOverride, false)
+                        .putBoolean(prefKeyHostEdgeOverride, false)
+                        .putBoolean(prefKeyHostGpuOverride, false).apply();
+                    Toast.makeText(getContext(), "Computer Vision hosts reset to default.", Toast.LENGTH_SHORT).show();
+                }
+                //Always set the value back to something so that either clicking Yes or No in the dialog
+                //will activate this "changed" call.
+                sharedPreferences.edit().putString(prefKeyResetCvHosts, "XXX_garbage_value").apply();
+
+                // Reinitialize this screen of preferences, since values may have changed.
+                // If an NPE occurs because the PreferenceManager has gone away,
+                // there's no need for any action. Just don't crash the app.
+                try {
+                    getPreferenceScreen().removeAll();
+                    addPreferencesFromResource(R.xml.pref_face_detection);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/SettingsActivity.java
@@ -180,7 +180,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
             String prefKeyHostCloud = getResources().getString(R.string.preference_fd_host_cloud);
             String prefKeyHostEdge = getResources().getString(R.string.preference_fd_host_edge);
-            String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_openpose_host_edge);
+            String prefKeyOpenPoseHostEdge = getResources().getString(R.string.preference_gpu_host_edge);
 
             bindPreferenceSummaryToValue(findPreference(prefKeyHostCloud));
             bindPreferenceSummaryToValue(findPreference(prefKeyHostEdge));

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="preference_fd_show_latency_stats_dialog">fd_show_latency_stats_dialog</string>
     <string name="preference_fd_show_latency_stats_dialog_title">Show Latency Stats after session</string>
     <string name="preference_fd_show_latency_stats_dialog_summary">Show a dialog with copyable latency stats after ending camera session.</string>
-    <string-array name="pref_fd_reset_both_hosts_choices">
+    <string-array name="pref_fd_reset_all_hosts_choices">
         <item>Yes. Reset hosts to default.</item>
         <item>No. Retain current values.</item>
     </string-array>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -47,9 +47,9 @@
     <string name="preference_fd_host_edge">fd_host_edge</string>
     <string name="preference_fd_host_edge_title">Edge Server</string>
     <string name="preference_fd_host_edge_summary">Enter a custom IP or hostname.</string>
-    <string name="preference_fd_reset_both_hosts">fd_reset_both_hosts</string>
-    <string name="preference_fd_reset_both_hosts_title">Reset hosts to default.</string>
-    <string name="preference_fd_reset_both_hosts_message">Are you sure?</string>
+    <string name="preference_fd_reset_all_hosts">fd_reset_both_hosts</string>
+    <string name="preference_fd_reset_all_hosts_title">Reset hosts to default.</string>
+    <string name="preference_fd_reset_all_hosts_message">Are you sure?</string>
     <string name="preference_fd_legacy_camera">fd_legacy_camera</string>
     <string name="preference_fd_legacy_camera_title">Legacy Camera</string>
     <string name="preference_fd_legacy_camera_summary">Camera handling for older devices</string>
@@ -61,9 +61,9 @@
         <item>No. Retain current values.</item>
     </string-array>
     <string name="fd_latency_method">fd_latency_method</string>
-    <string name="preference_openpose_host_edge">fd_openpose_host_edge</string>
-    <string name="preference_openpose_host_edge_title">GPU Server (OpenPose, PyTorch)</string>
-    <string name="preference_openpose_host_edge_summary">Enter a custom IP or hostname.</string>
+    <string name="preference_gpu_host_edge">fd_gpu_host_edge</string>
+    <string name="preference_gpu_host_edge_title">GPU Server (OpenPose, PyTorch)</string>
+    <string name="preference_gpu_host_edge_summary">Enter a custom IP or hostname.</string>
     <string name="train_guest_start">Start</string>
     <string name="train_guest_title">Guest Name</string>
     <string name="train_guest_message">Enter the guest name, then face recognition training will begin.</string>
@@ -104,5 +104,13 @@
     <string name="pref_override_gpu_cloudlet_hostname">pref_override_gpu_cloudlet_hostname</string>
     <string name="pref_summary_override_gpu_cloudlet_hostname">Select this to enter a GPU hostname to override the FindCloudlet result.</string>
     <string name="pref_title_override_gpu_cloudlet_hostname">Override GPU cloudlet hostname</string>
+
+    <string name="pref_override_edge_cloudlet_hostname">pref_override_edge_cloudlet_hostname</string>
+    <string name="pref_summary_override_edge_cloudlet_hostname">Select this to enter an Edge Server hostname to override the FindCloudlet result.</string>
+    <string name="pref_title_override_edge_cloudlet_hostname">Override Edge cloudlet hostname</string>
+
+    <string name="pref_override_cloud_cloudlet_hostname">pref_override_cloud_cloudlet_hostname</string>
+    <string name="pref_summary_override_cloud_cloudlet_hostname">Select this to enter a Cloud Server hostname to override default provisioned value.</string>
+    <string name="pref_title_override_cloud_cloudlet_hostname">Override Cloud cloudlet hostname</string>
 
 </resources>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
@@ -67,17 +67,29 @@
         android:defaultValue="invalid"
         android:entries="@array/pref_fd_reset_both_hosts_choices"
         android:entryValues="@array/pref_fd_reset_both_hosts_choices"
-        android:key="@string/preference_fd_reset_both_hosts"
-        android:title="@string/preference_fd_reset_both_hosts_title" />
+        android:key="@string/preference_fd_reset_all_hosts"
+        android:title="@string/preference_fd_reset_all_hosts_title" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/pref_override_cloud_cloudlet_hostname"
+        android:summary="@string/pref_summary_override_cloud_cloudlet_hostname"
+        android:title="@string/pref_title_override_cloud_cloudlet_hostname" />
     <EditTextPreference
-        android:defaultValue="facedetection.defaultcloud.mobiledgex.net"
+        android:dependency="@string/pref_override_cloud_cloudlet_hostname"
+        android:defaultValue="Default"
         android:key="@string/preference_fd_host_cloud"
         android:selectAllOnFocus="true"
         android:singleLine="false"
         android:summary="@string/preference_fd_host_cloud_summary"
         android:title="@string/preference_fd_host_cloud_title" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/pref_override_edge_cloudlet_hostname"
+        android:summary="@string/pref_summary_override_edge_cloudlet_hostname"
+        android:title="@string/pref_title_override_edge_cloudlet_hostname" />
     <EditTextPreference
-        android:defaultValue="facedetection.defaultedge.mobiledgex.net"
+        android:dependency="@string/pref_override_edge_cloudlet_hostname"
+        android:defaultValue="Default"
         android:key="@string/preference_fd_host_edge"
         android:selectAllOnFocus="true"
         android:singleLine="false"
@@ -91,11 +103,11 @@
     <EditTextPreference
         android:dependency="@string/pref_override_gpu_cloudlet_hostname"
         android:defaultValue="posedetection.defaultedge.mobiledgex.net"
-        android:key="@string/preference_openpose_host_edge"
+        android:key="@string/preference_gpu_host_edge"
         android:selectAllOnFocus="true"
         android:singleLine="false"
-        android:summary="@string/preference_openpose_host_edge_summary"
-        android:title="@string/preference_openpose_host_edge_title" />
+        android:summary="@string/preference_gpu_host_edge_summary"
+        android:title="@string/preference_gpu_host_edge_title" />
     <SwitchPreference
         android:key="@string/preference_fd_show_latency_stats_dialog"
         android:title="@string/preference_fd_show_latency_stats_dialog_title"

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_face_detection.xml
@@ -65,8 +65,8 @@
         android:defaultValue="true" />
     <ListPreference
         android:defaultValue="invalid"
-        android:entries="@array/pref_fd_reset_both_hosts_choices"
-        android:entryValues="@array/pref_fd_reset_both_hosts_choices"
+        android:entries="@array/pref_fd_reset_all_hosts_choices"
+        android:entryValues="@array/pref_fd_reset_all_hosts_choices"
         android:key="@string/preference_fd_reset_all_hosts"
         android:title="@string/preference_fd_reset_all_hosts_title" />
     <CheckBoxPreference


### PR DESCRIPTION
- Provisioning data is downloaded from http://opencv.facetraining.mobiledgex.net/cvprovisioning.json.
- Removed usage of facedetection.defaultXXX.mobiledgex.net hostnames.
- Override settings to allow custom hostnames and ignore provisioning data.
- Better handling of TLS, disabling it for GCP app instances.
- Removed old preferences code from MainActivity that was replicated to computervision.ImageProcessorFragment and should have been removed long ago.

Testing still in progress, but I wanted folks to be able to start taking a look because this is a pretty sizable update.
