### PR TITLE
EDGECLOUD-4042 Patch OpenPose build to avoid error

### DIFF
--- a/ComputerVisionServer/Dockerfile_gpu
+++ b/ComputerVisionServer/Dockerfile_gpu
@@ -20,7 +20,13 @@ RUN git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose.git .
 WORKDIR /openpose/build
 #patch because dataset server posefs1.perception.cs.cmu.edu horribly slow (2020-09-04)
 RUN sed -i 's/posefs1.perception.cs.cmu.edu/opencv.facetraining.mobiledgex.net/g' /openpose/CMakeLists.txt
-RUN cmake -DBUILD_PYTHON=ON .. && make -j `nproc`
+# patch to comment this line out because our version of Cuda doesn't support AMPERE architecture
+# TODO: 2020-12-01: When 11.0-cudnn8-devel-ubuntu20.04 is available, we will revisit this.
+# Check for updates here: https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
+RUN sed -i 's/set(AMPERE "80 86")/#set(AMPERE "80 86")/g' /openpose/cmake/Cuda.cmake
+RUN cmake -DBUILD_PYTHON=ON ..
+RUN sed -i 's/set(AMPERE "80 86")/#set(AMPERE "80 86")/g' /openpose/3rdparty/caffe/cmake/Cuda.cmake
+RUN make -j `nproc`
 
 # Use a virtualenv for all of our Python requirements.
 RUN apt-get install -y python3.7-venv

--- a/ComputerVisionServer/moedx/client/remote_bench.py
+++ b/ComputerVisionServer/moedx/client/remote_bench.py
@@ -1,4 +1,21 @@
-# This script is for launching multiple simultaneous multi_client instances to benchmark a given server.
+# Copyright 2020 MobiledgeX, Inc. All rights and licenses reserved.
+# MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script is for launching multiple simultaneous multi_client instances to benchmark a given server.
+"""
 
 import sys
 import os

--- a/ComputerVisionServer/moedx/object_detection/object_detectron2.py
+++ b/ComputerVisionServer/moedx/object_detection/object_detectron2.py
@@ -42,11 +42,8 @@ classes = MetadataCatalog.get(cfg.DATASETS.TRAIN[0]).thing_classes
 # create predictor
 predictor = DefaultPredictor(cfg)
 
+# TODO: Programmatically determine if GPU support exists.
 gpu_support = False
-# if torch.cuda.is_available():
-#     gpu_support = True
-# else:
-#     cfg.MODEL.DEVICE = "cpu" # use a CPU Detectron copy
 
 # Globals
 total_server_processing_time = 0


### PR DESCRIPTION
- Patch to comment Nvidia AMPERE support out of OpenPose to allow us to continue building with CUDA 10.
- Adding copyright to a file that are pointed to by soon-to-be-released blog post.
- Removed dead code and added TODO to object_detectron2.py.