### PR TITLE
EDGECLOUD-4594 Removing hardcoded EdgeEvent host and adding NetTest option

### DIFF
--- a/android/MobiledgeXSDKDemo/app/src/androidTest/java/com/mobiledgex/sdkdemo/MatchingEngineUnitTest.java
+++ b/android/MobiledgeXSDKDemo/app/src/androidTest/java/com/mobiledgex/sdkdemo/MatchingEngineUnitTest.java
@@ -47,7 +47,6 @@ public class MatchingEngineUnitTest {
     public static final String carrierName = "wifi";
     public static final String authToken = null;
     public static final int cellID = 0;
-    public static final List<AppClient.Tag> tags = new ArrayList<>();
     public static final int lteCategory = 0;
     public static final AppClient.BandSelection bandSelection = null;
 

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -74,6 +74,7 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
         }
         Log.i(TAG, "cloudlet="+cloudlet+" "+cloudlet.getCloudletName());
         cloudlet.setSpeedTestResultsListener(this);
+        cloudlet.setContext(getApplicationContext());
 
         cloudletNameTv = findViewById(R.id.cloudletName);
         appNameTv = findViewById(R.id.appName);

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletListHolder.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletListHolder.java
@@ -62,7 +62,8 @@ public class CloudletListHolder {
 
     public enum LatencyTestMethod {
         ping,
-        socket
+        socket,
+        NetTest
     }
 
     private CloudletListHolder() {

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -105,10 +105,12 @@
     <string-array name="pref_latency_test_method_titles">
         <item>System Ping (ICMP)</item>
         <item>Socket</item>
+        <item>SDK NetTest</item>
     </string-array>
     <string-array name="pref_latency_test_method_values">
         <item>ping</item>
         <item>socket</item>
+        <item>NetTest</item>
     </string-array>
 
     <string name="pref_find_cloudlet_mode">find_cloudlet_mode</string>

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "2.3.6"
+project.ext.matchingengineVersion = "2.5.0"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
 
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // JFrog Artifactory:
@@ -46,6 +46,7 @@ allprojects {
             }
             url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
         }
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/android/MobiledgeXSDKDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/android/MobiledgeXSDKDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 01 11:45:49 CDT 2020
+#Tue Feb 02 14:11:09 CST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
- Removed hardcoded host and port numbers used for EdgeEvents demo with EdgeBox DME/app insts.
- Added "SDK NetTest" to "Latency Test Method" in Speed Test Settings.
- Code to use NetTest when it is selected.