### PR TITLE
EDGECLOUD-5092 TLS Setting for override hostname

### DIFF
--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/EdgeOnlyImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/EdgeOnlyImageProcessorFragment.java
@@ -166,7 +166,7 @@ public abstract class EdgeOnlyImageProcessorFragment extends ImageProcessorFragm
         String prefKeyHostGpuOverride = getResources().getString(R.string.pref_override_gpu_cloudlet_hostname);
         String prefKeyHostGpu = getResources().getString(R.string.preference_gpu_host_edge);
 
-        if (key.equals(prefKeyHostGpuOverride) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostGpuOverride) || key.equals(ALL_PREFS)) {
             mGpuHostNameOverride = sharedPreferences.getBoolean(prefKeyHostGpuOverride, false);
             Log.i(TAG, "key="+key+" mGpuHostNameOverride="+ mGpuHostNameOverride);
             if (mGpuHostNameOverride) {
@@ -174,7 +174,7 @@ public abstract class EdgeOnlyImageProcessorFragment extends ImageProcessorFragm
                 Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
             }
         }
-        if (key.equals(prefKeyHostGpu) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostGpu) || key.equals(ALL_PREFS)) {
             mHostDetectionEdge = sharedPreferences.getString(prefKeyHostGpu, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
         }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -91,6 +91,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
     private static final String TAG = "ImageProcessorFragment";
     public static final String EXTRA_FACE_STROKE_WIDTH = "EXTRA_FACE_STROKE_WIDTH";
     private static final String VIDEO_FILE_NAME = "Jason.mp4";
+    public static final String ALL_PREFS = "ALL";
 
     protected MatchingEngineHelper meHelper;
 
@@ -867,7 +868,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         String prefKeyHostTraining = getResources().getString(R.string.pref_cv_host_training);
 
         // Cloud Hostname handling
-        if (key.equals(prefKeyHostCloudOverride) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostCloudOverride) || key.equals(ALL_PREFS)) {
             mCloudHostNameOverride = sharedPreferences.getBoolean(prefKeyHostCloudOverride, false);
             Log.i(TAG, "key="+key+" mCloudHostNameOverride="+ mCloudHostNameOverride);
             if (mCloudHostNameOverride) {
@@ -876,13 +877,13 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
                 Log.i(TAG, "key="+key+" mHostDetectionCloud="+ mHostDetectionCloud);
             }
         }
-        if (key.equals(prefKeyHostCloud) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostCloud) || key.equals(ALL_PREFS)) {
             mHostDetectionCloud = sharedPreferences.getString(prefKeyHostCloud, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "prefKeyHostCloud="+prefKeyHostCloud+" mHostDetectionCloud="+ mHostDetectionCloud);
         }
 
         // Edge Hostname handling
-        if (key.equals(prefKeyHostEdgeOverride) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostEdgeOverride) || key.equals(ALL_PREFS)) {
             mEdgeHostNameOverride = sharedPreferences.getBoolean(prefKeyHostEdgeOverride, false);
             Log.i(TAG, "key="+key+" mEdgeHostNameOverride="+ mEdgeHostNameOverride);
             if (mEdgeHostNameOverride) {
@@ -892,11 +893,11 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
             mEdgeHostNameTls = sharedPreferences.getBoolean(prefKeyHostEdgeTls, false);
             Log.i(TAG, "prefKeyHostEdgeTls="+prefKeyHostEdgeTls+" mEdgeHostNameTls="+ mEdgeHostNameTls);
         }
-        if (key.equals(prefKeyHostEdge) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostEdge) || key.equals(ALL_PREFS)) {
             mHostDetectionEdge = sharedPreferences.getString(prefKeyHostEdge, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "prefKeyHostEdge="+prefKeyHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
         }
-        if (key.equals(prefKeyHostEdgeTls) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostEdgeTls) || key.equals(ALL_PREFS)) {
             mEdgeHostNameTls = sharedPreferences.getBoolean(prefKeyHostEdgeTls, false);
             Log.i(TAG, "prefKeyHostEdgeTls="+prefKeyHostEdgeTls+" mEdgeHostNameTls="+ mEdgeHostNameTls);
         }
@@ -910,18 +911,18 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
             }
         }
 
-        if (key.equals(prefKeyHostTraining) || key.equals("ALL")) {
+        if (key.equals(prefKeyHostTraining) || key.equals(ALL_PREFS)) {
             mHostTraining = sharedPreferences.getString(prefKeyHostTraining, DEF_FACE_HOST_TRAINING);
             Log.i(TAG, "prefKeyHostTraining="+prefKeyHostTraining+" mHostTraining="+mHostTraining);
         }
 
-        if (key.equals(prefKeyFrontCamera) || key.equals("ALL")) {
+        if (key.equals(prefKeyFrontCamera) || key.equals(ALL_PREFS)) {
             if(mCamera2BasicFragment != null) {
                 prefCameraLensFacingDirection = sharedPreferences.getInt(prefKeyFrontCamera, CameraCharacteristics.LENS_FACING_FRONT);
                 mCamera2BasicFragment.setCameraLensFacingDirection(prefCameraLensFacingDirection);
             }
         }
-        if (key.equals(prefKeyLatencyMethod) || key.equals("ALL")) {
+        if (key.equals(prefKeyLatencyMethod) || key.equals(ALL_PREFS)) {
             String latencyTestMethodString = sharedPreferences.getString(prefKeyLatencyMethod, defaultLatencyMethod);
             Log.i(TAG, "latencyTestMethod=" + latencyTestMethodString+" mImageSenderCloud="+mImageSenderCloud);
             if(mImageSenderCloud != null) {
@@ -931,30 +932,30 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
                 mImageSenderEdge.setLatencyTestMethod(ImageSender.LatencyTestMethod.valueOf(latencyTestMethodString));
             }
         }
-        if (key.equals(prefKeyConnectionMode) || key.equals("ALL")) {
+        if (key.equals(prefKeyConnectionMode) || key.equals(ALL_PREFS)) {
             String connectionModeString = sharedPreferences.getString(prefKeyConnectionMode, defaultConnectionMode);
             Log.i(TAG, "connectionMode=" + connectionModeString+" mImageSenderEdge="+mImageSenderEdge+" mImageSenderCloud="+mImageSenderCloud);
             ImageSender.setPreferencesConnectionMode(ImageSender.ConnectionMode.valueOf(connectionModeString), mImageSenderEdge, mImageSenderCloud);
         }
-        if (key.equals(prefKeyMultiFace) || key.equals("ALL")) {
+        if (key.equals(prefKeyMultiFace) || key.equals(ALL_PREFS)) {
             prefMultiFace = sharedPreferences.getBoolean(prefKeyMultiFace, true);
         }
-        if (key.equals(prefKeyShowFullLatency) || key.equals("ALL")) {
+        if (key.equals(prefKeyShowFullLatency) || key.equals(ALL_PREFS)) {
             prefShowFullLatency = sharedPreferences.getBoolean(prefKeyShowFullLatency, true);
         }
-        if (key.equals(prefKeyShowNetLatency) || key.equals("ALL")) {
+        if (key.equals(prefKeyShowNetLatency) || key.equals(ALL_PREFS)) {
             prefShowNetLatency = sharedPreferences.getBoolean(prefKeyShowNetLatency, true);
         }
-        if (key.equals(prefKeyShowStdDev) || key.equals("ALL")) {
+        if (key.equals(prefKeyShowStdDev) || key.equals(ALL_PREFS)) {
             prefShowStdDev = sharedPreferences.getBoolean(prefKeyShowStdDev, false);
         }
-        if (key.equals(prefKeyUseRollingAvg) || key.equals("ALL")) {
+        if (key.equals(prefKeyUseRollingAvg) || key.equals(ALL_PREFS)) {
             prefUseRollingAvg = sharedPreferences.getBoolean(prefKeyUseRollingAvg, false);
         }
-        if (key.equals(prefKeyAutoFailover) || key.equals("ALL")) {
+        if (key.equals(prefKeyAutoFailover) || key.equals(ALL_PREFS)) {
             prefAutoFailover = sharedPreferences.getBoolean(prefKeyAutoFailover, true);
         }
-        if (key.equals(prefKeyShowCloudOutput) || key.equals("ALL")) {
+        if (key.equals(prefKeyShowCloudOutput) || key.equals(ALL_PREFS)) {
             prefShowCloudOutput = sharedPreferences.getBoolean(prefKeyShowCloudOutput, true);
         }
 
@@ -1049,7 +1050,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         prefs.registerOnSharedPreferenceChangeListener(this);
         // Get preferences for everything we've instantiated so far.
-        onSharedPreferenceChanged(prefs, "ALL");
+        onSharedPreferenceChanged(prefs, ALL_PREFS);
 
         Intent intent = getActivity().getIntent();
         getCommonIntentExtras(intent);
@@ -1228,7 +1229,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
 
         //One more call to get preferences for ImageSenders
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        onSharedPreferenceChanged(prefs, "ALL");
+        onSharedPreferenceChanged(prefs, ALL_PREFS);
     }
 
     protected void getCommonIntentExtras(Intent intent) {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -154,6 +154,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
 
     protected boolean mGpuHostNameOverride = false;
     protected boolean mEdgeHostNameOverride = false;
+    protected boolean mEdgeHostNameTls = false;
     private boolean mCloudHostNameOverride = false;
 
     public static final String EXTRA_FACE_RECOGNITION = "EXTRA_FACE_RECOGNITION";
@@ -328,11 +329,15 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         }
         Log.i(TAG, message);
         showMessage(message);
+        boolean tls = mTlsEdge;
+        if (mEdgeHostNameOverride) {
+            tls = mEdgeHostNameTls;
+        }
         mImageSenderEdge = new ImageSender.Builder()
                 .setActivity(getActivity())
                 .setImageServerInterface(this)
                 .setCloudLetType(CloudletType.EDGE)
-                .setTls(mTlsEdge)
+                .setTls(tls)
                 .setHost(mHostDetectionEdge)
                 .setPort(FACE_DETECTION_HOST_PORT)
                 .setPersistentTcpPort(PERSISTENT_TCP_PORT)
@@ -858,6 +863,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         String prefKeyHostCloud = getResources().getString(R.string.pref_cv_host_cloud);
         String prefKeyHostEdgeOverride = getResources().getString(R.string.pref_override_edge_cloudlet_hostname);
         String prefKeyHostEdge = getResources().getString(R.string.pref_cv_host_edge);
+        String prefKeyHostEdgeTls = getResources().getString(R.string.pref_cv_host_edge_tls);
         String prefKeyHostTraining = getResources().getString(R.string.pref_cv_host_training);
 
         // Cloud Hostname handling
@@ -883,10 +889,16 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
                 mHostDetectionEdge = sharedPreferences.getString(prefKeyHostEdge, DEF_HOSTNAME_PLACEHOLDER);
                 Log.i(TAG, "key="+key+" mHostDetectionEdge="+ mHostDetectionEdge);
             }
+            mEdgeHostNameTls = sharedPreferences.getBoolean(prefKeyHostEdgeTls, false);
+            Log.i(TAG, "prefKeyHostEdgeTls="+prefKeyHostEdgeTls+" mEdgeHostNameTls="+ mEdgeHostNameTls);
         }
         if (key.equals(prefKeyHostEdge) || key.equals("ALL")) {
             mHostDetectionEdge = sharedPreferences.getString(prefKeyHostEdge, DEF_HOSTNAME_PLACEHOLDER);
             Log.i(TAG, "prefKeyHostEdge="+prefKeyHostEdge+" mHostDetectionEdge="+ mHostDetectionEdge);
+        }
+        if (key.equals(prefKeyHostEdgeTls) || key.equals("ALL")) {
+            mEdgeHostNameTls = sharedPreferences.getBoolean(prefKeyHostEdgeTls, false);
+            Log.i(TAG, "prefKeyHostEdgeTls="+prefKeyHostEdgeTls+" mEdgeHostNameTls="+ mEdgeHostNameTls);
         }
         if (key.equals(prefKeyHostEdge) || key.equals(prefKeyHostEdgeOverride)) {
             if (mEdgeHostNameOverride) {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -128,7 +128,7 @@ public class ObjectProcessorFragment extends EdgeOnlyImageProcessorFragment impl
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         prefs.registerOnSharedPreferenceChangeListener(this);
-        onSharedPreferenceChanged(prefs, "ALL");
+        onSharedPreferenceChanged(prefs, ALL_PREFS);
 
         Intent intent = getActivity().getIntent();
         getCommonIntentExtras(intent);

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -130,7 +130,7 @@ public class PoseProcessorFragment extends EdgeOnlyImageProcessorFragment implem
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         prefs.registerOnSharedPreferenceChangeListener(this);
-        onSharedPreferenceChanged(prefs, "ALL");
+        onSharedPreferenceChanged(prefs, ALL_PREFS);
 
         Intent intent = getActivity().getIntent();
         getCommonIntentExtras(intent);

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -46,6 +46,9 @@
     <string name="pref_cv_host_edge">fd_host_edge</string>
     <string name="pref_cv_host_edge_title">Edge Server</string>
     <string name="pref_cv_host_edge_summary">Enter a custom IP or hostname.</string>
+    <string name="pref_cv_host_edge_tls">fd_host_edge_tls</string>
+    <string name="pref_cv_host_edge_tls_title">TLS Enabled</string>
+    <string name="pref_cv_host_edge_tls_summary">Turn on to enable TLS for overridden hostname.</string>
     <string name="pref_cv_reset_all_hosts">fd_reset_both_hosts</string>
     <string name="pref_cv_reset_all_hosts_title">Reset hosts to default.</string>
     <string name="pref_cv_reset_all_hosts_message">Are you sure?</string>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_overrides.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_overrides.xml
@@ -20,6 +20,12 @@
         android:summary="@string/pref_cv_host_edge_summary"
         android:title="@string/pref_cv_host_edge_title"
         app:iconSpaceReserved="false"/>
+    <SwitchPreference
+        android:defaultValue="false"
+        android:dependency="@string/pref_override_edge_cloudlet_hostname"
+        android:key="@string/pref_cv_host_edge_tls"
+        android:summary="@string/pref_cv_host_edge_tls_summary"
+        android:title="@string/pref_cv_host_edge_tls_title" />
     <CheckBoxPreference
         android:defaultValue="false"
         android:key="@string/pref_override_gpu_cloudlet_hostname"


### PR DESCRIPTION
Default was to always enable TLS, so we couldn't connect to a non-TLS server in the case of hostname override. New "TLS Enabled" switch setting that is only used when "Override Edge cloudlet hostname" is enabled.

When override is disabled, the TLS setting from the port section of the findCloudlet result is used.