### PR TITLE
EDGECLOUD-4658 Workshop updates

### DIFF
--- a/android/WorkshopCompleted/.idea/compiler.xml
+++ b/android/WorkshopCompleted/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/android/WorkshopCompleted/.idea/misc.xml
+++ b/android/WorkshopCompleted/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/WorkshopCompleted/.idea/runConfigurations.xml
+++ b/android/WorkshopCompleted/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/android/WorkshopCompleted/app/build.gradle
+++ b/android/WorkshopCompleted/app/build.gradle
@@ -5,11 +5,11 @@ def grpcVersion = '1.32.1'
 
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.mobiledgex.workshopskeleton"
         minSdkVersion 24
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -41,7 +41,7 @@ dependencies {
     implementation 'androidx.ads:ads-identifier:1.0.0-alpha04'
 
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:2.4.0'
+    implementation 'com.mobiledgex:matchingengine:2.4.2'
     implementation 'com.mobiledgex:mel:1.0.11'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/android/WorkshopCompleted/app/src/androidTest/java/com/mobiledgex/workshopskeleton/ExampleInstrumentedTest.java
+++ b/android/WorkshopCompleted/app/src/androidTest/java/com/mobiledgex/workshopskeleton/ExampleInstrumentedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +18,14 @@
 package com.mobiledgex.workshopskeleton;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -36,7 +37,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         assertEquals("com.mobiledgex.workshopskeleton", appContext.getPackageName());
     }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -288,7 +288,7 @@ public class MainActivity extends AppCompatActivity
         // an existing app so we don't have to create new app provisioning data for this workshop.
         appName = "ComputerVision";
         orgName = "MobiledgeX-Samples";
-        carrierName = "TDG";
+        carrierName = "Magenta";
         appVersion = "2.2";
 
         //NOTICE: A real app would request permission to enable this.
@@ -304,7 +304,7 @@ public class MainActivity extends AppCompatActivity
         port = matchingEngine.getPort(); // Keep same port.
         AppClient.RegisterClientRequest registerClientRequest;
         registerClientRequest = matchingEngine.createDefaultRegisterClientRequest(ctx, orgName)
-                .setAppName(appName).setAppVers(appVersion).build();
+                .setAppName(appName).setAppVers(appVersion).setCarrierName(carrierName).build();
         Log.i(TAG, "registerClientRequest: host="+host+" port="+port
                 +" getAppName()="+registerClientRequest.getAppName()
                 +" getAppVers()="+registerClientRequest.getAppVers()
@@ -347,7 +347,8 @@ public class MainActivity extends AppCompatActivity
         ////////////////////////////////////////////////////////////////////////////////////////////
         // TODO: Copy/paste the code to find the cloudlet closest to you. Replace "= null" here.
         AppClient.FindCloudletRequest findCloudletRequest;
-        findCloudletRequest = matchingEngine.createDefaultFindCloudletRequest(ctx, location).build();
+        findCloudletRequest = matchingEngine.createDefaultFindCloudletRequest(ctx, location)
+                .setCarrierName(carrierName).build();
         mClosestCloudlet = matchingEngine.findCloudlet(findCloudletRequest, host, port, 10000);
         ////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -376,7 +377,7 @@ public class MainActivity extends AppCompatActivity
 
         // Extract cloudlet name from FQDN
         String[] parts = mClosestCloudlet.getFqdn().split("\\.");
-        cloudletNameTvStr = parts[0];
+        cloudletNameTvStr = parts[1];
 
         //Find FqdnPrefix from Port structure.
         String FqdnPrefix = "";

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -288,7 +288,7 @@ public class MainActivity extends AppCompatActivity
         // an existing app so we don't have to create new app provisioning data for this workshop.
         appName = "ComputerVision";
         orgName = "MobiledgeX-Samples";
-        carrierName = "Magenta";
+        carrierName = "TDG";
         appVersion = "2.2";
 
         //NOTICE: A real app would request permission to enable this.

--- a/android/WorkshopCompleted/app/src/test/java/com/mobiledgex/workshopskeleton/ExampleUnitTest.java
+++ b/android/WorkshopCompleted/app/src/test/java/com/mobiledgex/workshopskeleton/ExampleUnitTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopCompleted/build.gradle
+++ b/android/WorkshopCompleted/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.6"
 
         // JFrog Artifactory:

--- a/android/WorkshopCompleted/gradle/wrapper/gradle-wrapper.properties
+++ b/android/WorkshopCompleted/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/android/WorkshopSkeleton/.idea/compiler.xml
+++ b/android/WorkshopSkeleton/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/android/WorkshopSkeleton/.idea/misc.xml
+++ b/android/WorkshopSkeleton/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/WorkshopSkeleton/.idea/runConfigurations.xml
+++ b/android/WorkshopSkeleton/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/android/WorkshopSkeleton/app/build.gradle
+++ b/android/WorkshopSkeleton/app/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.jfrog.artifactory'
 def grpcVersion = '1.32.1'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.mobiledgex.workshopskeleton"
         minSdkVersion 24
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:15.0.1'
 
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:2.4.0'
+    implementation 'com.mobiledgex:matchingengine:2.4.2'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"

--- a/android/WorkshopSkeleton/app/src/androidTest/java/com/mobiledgex/workshopskeleton/ExampleInstrumentedTest.java
+++ b/android/WorkshopSkeleton/app/src/androidTest/java/com/mobiledgex/workshopskeleton/ExampleInstrumentedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +18,14 @@
 package com.mobiledgex.workshopskeleton;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -36,7 +37,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         assertEquals("com.mobiledgex.workshopskeleton", appContext.getPackageName());
     }

--- a/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
+++ b/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
+++ b/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopSkeleton/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +106,7 @@ public class MainActivity extends AppCompatActivity
     private String latitudeTvStr = "";
     private TextView longitudeTv;
     private String longitudeTvStr = "";
-    private String mClosestCloudletHostName;
+    private String mClosestCloudletHostname;
 
     private CheckBox checkboxRegistered;
     private CheckBox checkboxCloudletFound;
@@ -214,7 +214,7 @@ public class MainActivity extends AppCompatActivity
 
         if (id == R.id.action_reset) {
             mClosestCloudlet = null;
-            mClosestCloudletHostName = null;
+            mClosestCloudletHostname = null;
             carrierNameTv.setText("none");
             appNameTv.setText("none");
             latitudeTv.setText("none");
@@ -344,12 +344,12 @@ public class MainActivity extends AppCompatActivity
 
         // Extract cloudlet name from FQDN
         String[] parts = mClosestCloudlet.getFqdn().split("\\.");
-        cloudletNameTvStr = parts[0];
+        cloudletNameTvStr = parts[1];
 
         //Find FqdnPrefix from Port structure.
         String FqdnPrefix = "";
         List<distributed_match_engine.Appcommon.AppPort> ports = mClosestCloudlet.getPortsList();
-        String appPortFormat = "{Protocol: %d, FqdnPrefix: %s, Container Port: %d, External Port: %d, Public Path: '%s'}";
+        String appPortFormat = "{Protocol: %d, Container Port: %d, External Port: %d, Path Prefix: '%s'}";
         for (Appcommon.AppPort aPort : ports) {
             FqdnPrefix = aPort.getFqdnPrefix();
             // assign first port number to portNumberTvStr
@@ -358,16 +358,15 @@ public class MainActivity extends AppCompatActivity
             }
             Log.i(TAG, String.format(Locale.getDefault(), appPortFormat,
                     aPort.getProto().getNumber(),
-                    aPort.getFqdnPrefix(),
                     aPort.getInternalPort(),
                     aPort.getPublicPort(),
-                    aPort.getPathPrefix()));
+                    aPort.getEndPort()));
         }
         // Build full hostname.
-        mClosestCloudletHostName = FqdnPrefix+mClosestCloudlet.getFqdn();
+        mClosestCloudletHostname = FqdnPrefix+mClosestCloudlet.getFqdn();
 
         // TODO: Copy/paste the output of this log into a terminal to test latency.
-        Log.i("COPY_PASTE", "ping -c 4 "+mClosestCloudletHostName);
+        Log.i("COPY_PASTE", "ping -c 4 "+mClosestCloudletHostname);
 
         verifyLocationInBackground(location);
 

--- a/android/WorkshopSkeleton/app/src/main/res/layout/app_bar_main.xml
+++ b/android/WorkshopSkeleton/app/src/main/res/layout/app_bar_main.xml
@@ -46,7 +46,7 @@
         android:id="@+id/textViewCopyright"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved."
+        android:text="Copyright 2021 MobiledgeX, Inc. All rights and licenses reserved."
         android:textColor="#999999"
         android:textSize="12sp"
         app:layout_anchor="@+id/include"

--- a/android/WorkshopSkeleton/app/src/test/java/com/mobiledgex/workshopskeleton/ExampleUnitTest.java
+++ b/android/WorkshopSkeleton/app/src/test/java/com/mobiledgex/workshopskeleton/ExampleUnitTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2019-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/android/WorkshopSkeleton/build.gradle
+++ b/android/WorkshopSkeleton/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.6"
 
         // JFrog Artifactory:

--- a/android/WorkshopSkeleton/gradle/wrapper/gradle-wrapper.properties
+++ b/android/WorkshopSkeleton/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
- Remove call to non-existent getPathPrefix
- Updated to matchingengine 2.4.2.
- Fixed bug where we were not including the setCarrierName call to build DME requests.
- Updated copyright dates.
- Library and plugin updates recommended by Android Studio
- Changes to sample unit test code required because of those updates.