### PR TITLE
Latency stats cleanup

### DIFF
--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -82,6 +82,10 @@ import distributed_match_engine.Appcommon;
 
 import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEF_HOSTNAME_PLACEHOLDER;
 
+/**
+ * This class is used for image processing on both an Edge cloudlet app instance
+ * (displayed as "Edge"), and a public cloud app instance (displayed as "Cloud").
+ */
 public class ImageProcessorFragment extends Fragment implements MatchingEngineHelperInterface,
         ImageServerInterface, ImageProviderInterface,
         ActivityCompat.OnRequestPermissionsResultCallback,
@@ -153,7 +157,6 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
     protected List<String> mEdgeHostList = new ArrayList<>();
     protected int mEdgeHostListIndex;
 
-    protected boolean mGpuHostNameOverride = false;
     protected boolean mEdgeHostNameOverride = false;
     protected boolean mEdgeHostNameTls = false;
     private boolean mCloudHostNameOverride = false;
@@ -166,6 +169,8 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
     protected String mVideoFilename;
     protected boolean mAttached;
     protected EventLogViewer mEventLogViewer;
+    protected int fullLatencyEdgeLabel;
+    protected int networkLatencyEdgeLabel;
 
     /**
      * Return statistics information to be displayed in dialog after activity -- a combination
@@ -490,7 +495,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         final long stdDev = rollingAverage.getStdDev();
         final long latency;
         if (rollingAverage.getCurrent() == 0) {
-            latency = (long)9999*1000*1000; //to indicate connection error.
+            latency = (long)9999; //to indicate connection error.
         } else {
             if (prefUseRollingAvg) {
                 latency = rollingAverage.getAverage();
@@ -508,12 +513,12 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
             public void run() {
                 switch(cloudletType) {
                     case EDGE:
-                        mEdgeLatencyFull.setText("Edge: " + String.valueOf(latency / 1000000) + " ms");
-                        mEdgeStdFull.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev / 1000000) + " ms");
+                        mEdgeLatencyFull.setText(getResources().getString(fullLatencyEdgeLabel, latency));
+                        mEdgeStdFull.setText(getResources().getString(R.string.stddev_label, stdDev));
                         break;
                     case CLOUD:
-                        mCloudLatencyFull.setText("Cloud: " + String.valueOf(latency / 1000000) + " ms");
-                        mCloudStdFull.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev / 1000000) + " ms");
+                        mCloudLatencyFull.setText(getResources().getString(R.string.cloud_label, latency));
+                        mCloudStdFull.setText(getResources().getString(R.string.stddev_label, stdDev));
                         break;
                     default:
                         break;
@@ -528,7 +533,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
         final long stdDev = rollingAverage.getStdDev();
         final long latency;
         if (rollingAverage.getCurrent() == 0) {
-            latency = (long)9999*1000*1000; //to indicate connection error.
+            latency = (long)9999; //to indicate connection error.
         } else {
             if (prefUseRollingAvg) {
                 latency = rollingAverage.getAverage();
@@ -546,12 +551,12 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
             public void run() {
                 switch(cloudletType) {
                     case EDGE:
-                        mEdgeLatencyNet.setText("Edge: " + String.valueOf(latency / 1000000) + " ms");
-                        mEdgeStdNet.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev / 1000000) + " ms");
+                        mEdgeLatencyNet.setText(getResources().getString(networkLatencyEdgeLabel, latency));
+                        mEdgeStdNet.setText(getResources().getString(R.string.stddev_label, stdDev));
                         break;
                     case CLOUD:
-                        mCloudLatencyNet.setText("Cloud: " + String.valueOf(latency / 1000000) + " ms");
-                        mCloudStdNet.setText("Stddev: " + new DecimalFormat("#.##").format(stdDev / 1000000) + " ms");
+                        mCloudLatencyNet.setText(getResources().getString(R.string.cloud_label, latency));
+                        mCloudStdNet.setText(getResources().getString(R.string.stddev_label, stdDev));
                         break;
                     default:
                         break;
@@ -1071,6 +1076,19 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
             mCameraMode = ImageSender.CameraMode.FACE_DETECTION;
             mCameraToolbar.setTitle(R.string.title_activity_face_detection);
         }
+
+        // Initialize all values to 0, otherwise we would see the formatting string "%d" all over the UI.
+        mEdgeLatencyFull.setText(getResources().getString(R.string.edge_label, 0));
+        mEdgeStdFull.setText(getResources().getString(R.string.stddev_label, 0));
+        mEdgeLatencyNet.setText(getResources().getString(R.string.edge_label, 0));
+        mEdgeStdNet.setText(getResources().getString(R.string.stddev_label, 0));
+        mCloudLatencyFull.setText(getResources().getString(R.string.cloud_label, 0));
+        mCloudStdFull.setText(getResources().getString(R.string.stddev_label, 0));
+        mCloudLatencyNet.setText(getResources().getString(R.string.cloud_label, 0));
+        mCloudStdNet.setText(getResources().getString(R.string.stddev_label, 0));
+
+        fullLatencyEdgeLabel = R.string.edge_label;
+        networkLatencyEdgeLabel = R.string.edge_label;
 
         meHelper = new MatchingEngineHelper.Builder()
                 .setActivity(getActivity())

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageSender.java
@@ -23,7 +23,6 @@ import android.graphics.Bitmap;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.util.Base64;
 import android.util.Log;
 
 import com.android.volley.DefaultRetryPolicy;
@@ -570,9 +569,9 @@ public class ImageSender {
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        mLatencyFullProcessRollingAvg.add(latency);
+        mLatencyFullProcessRollingAvg.add(latency / 1000000); //ns->ms
         mImageServerInterface.updateFullProcessStats(mCloudLetType, mLatencyFullProcessRollingAvg);
-        Log.d(TAG, mCloudLetType + " mCameraMode=" + mCameraMode + " mLatency=" + (mLatency / 1000000.0)+" mHost="+mHost);
+        Log.d(TAG, mCloudLetType + " mCameraMode=" + mCameraMode + " mLatency=" + (latency / 1000000.0) + " mHost="+mHost);
     }
 
     /**
@@ -700,7 +699,7 @@ public class ImageSender {
                         matcher = pattern.matcher(inputLine);
                         if (matcher.find()) {
                             Log.d(TAG, "ping output=" + matcher.group(0));
-                            latency = (long) (Double.parseDouble(matcher.group(1)) * 1000000.0);
+                            latency = (long) (Double.parseDouble(matcher.group(1)));
                             rollingAverage.add(latency);
                         }
                         break;
@@ -724,8 +723,8 @@ public class ImageSender {
             if (reachable) {
                 long endTime = System.nanoTime();
                 latency = endTime - startTime;
-                rollingAverage.add(latency);
-                Log.d(TAG, host + " reachable=" + reachable + " Latency=" + (latency / 1000000.0) + " ms.");
+                rollingAverage.add(latency / 1000000);
+                Log.d(TAG, host + " reachable=" + reachable + " Latency=" + latency + " ms.");
             } else {
                 Log.d(TAG, host + " reachable=" + reachable);
             }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -19,8 +19,6 @@ package com.mobiledgex.computervision;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.graphics.Bitmap;
-import android.graphics.Rect;
 import android.hardware.camera2.CameraCharacteristics;
 import android.os.Bundle;
 import android.os.Handler;
@@ -32,11 +30,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mobiledgex.matchingenginehelper.EventLogViewer;
@@ -44,9 +39,7 @@ import com.mobiledgex.matchingenginehelper.MatchingEngineHelper;
 
 import org.json.JSONArray;
 
-import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEF_HOSTNAME_PLACEHOLDER;
-
-public class ObjectProcessorFragment extends EdgeOnlyImageProcessorFragment implements ImageServerInterface,
+public class ObjectProcessorFragment extends GpuImageProcessorFragment implements ImageServerInterface,
         ImageProviderInterface {
     private static final String TAG = "ObjectProcessorFragment";
     private static final String VIDEO_FILE_NAME = "objects.mp4";
@@ -138,6 +131,15 @@ public class ObjectProcessorFragment extends EdgeOnlyImageProcessorFragment impl
 
         mVideoFilename = VIDEO_FILE_NAME;
 
+        // Initialize all values to 0, otherwise we would see the formatting string "%d" all over the UI.
+        mEdgeLatencyFull.setText(getResources().getString(R.string.full_process_latency_label, 0));
+        mEdgeStdFull.setText(getResources().getString(R.string.stddev_label, 0));
+        mEdgeLatencyNet.setText(getResources().getString(R.string.edge_label, 0));
+        mEdgeStdNet.setText(getResources().getString(R.string.stddev_label, 0));
+
+        fullLatencyEdgeLabel = R.string.full_process_latency_label;
+        networkLatencyEdgeLabel = R.string.network_latency_label;
+
         meHelper = new MatchingEngineHelper.Builder()
                 .setActivity(getActivity())
                 .setMeHelperInterface(this)
@@ -147,11 +149,11 @@ public class ObjectProcessorFragment extends EdgeOnlyImageProcessorFragment impl
 
         setAppNameForGpu();
 
-        if (mGpuHostNameOverride) {
+        if (mEdgeHostNameOverride) {
             mEdgeHostList.clear();
             mEdgeHostListIndex = 0;
             mEdgeHostList.add(mHostDetectionEdge);
-            showMessage("Overriding GPU host. Host=" + mHostDetectionEdge);
+            showMessage("Overriding Edge host. Host=" + mHostDetectionEdge);
             restartImageSenderEdge();
         } else {
             meHelper.findCloudletInBackground();

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -19,8 +19,6 @@ package com.mobiledgex.computervision;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.graphics.Bitmap;
-import android.graphics.Rect;
 import android.hardware.camera2.CameraCharacteristics;
 import android.os.Bundle;
 import android.os.Handler;
@@ -32,11 +30,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mobiledgex.matchingenginehelper.EventLogViewer;
@@ -44,9 +39,7 @@ import com.mobiledgex.matchingenginehelper.MatchingEngineHelper;
 
 import org.json.JSONArray;
 
-import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEF_HOSTNAME_PLACEHOLDER;
-
-public class PoseProcessorFragment extends EdgeOnlyImageProcessorFragment implements ImageServerInterface,
+public class PoseProcessorFragment extends GpuImageProcessorFragment implements ImageServerInterface,
         ImageProviderInterface {
     private static final String TAG = "PoseProcessorFragment";
     public static final String EXTRA_POSE_STROKE_WIDTH = "EXTRA_POSE_STROKE_WIDTH";
@@ -146,6 +139,15 @@ public class PoseProcessorFragment extends EdgeOnlyImageProcessorFragment implem
 
         mVideoFilename = VIDEO_FILE_NAME;
 
+        // Initialize all values to 0, otherwise we would see the formatting string "%d" all over the UI.
+        mEdgeLatencyFull.setText(getResources().getString(R.string.full_process_latency_label, 0));
+        mEdgeStdFull.setText(getResources().getString(R.string.stddev_label, 0));
+        mEdgeLatencyNet.setText(getResources().getString(R.string.edge_label, 0));
+        mEdgeStdNet.setText(getResources().getString(R.string.stddev_label, 0));
+
+        fullLatencyEdgeLabel = R.string.full_process_latency_label;
+        networkLatencyEdgeLabel = R.string.network_latency_label;
+
         meHelper = new MatchingEngineHelper.Builder()
                 .setActivity(getActivity())
                 .setMeHelperInterface(this)
@@ -155,11 +157,11 @@ public class PoseProcessorFragment extends EdgeOnlyImageProcessorFragment implem
 
         setAppNameForGpu();
 
-        if (mGpuHostNameOverride) {
+        if (mEdgeHostNameOverride) {
             mEdgeHostList.clear();
             mEdgeHostListIndex = 0;
             mEdgeHostList.add(mHostDetectionEdge);
-            showMessage("Overriding GPU host. Host=" + mHostDetectionEdge);
+            showMessage("Overriding Edge host. Host=" + mHostDetectionEdge);
             restartImageSenderEdge();
         } else {
             meHelper.findCloudletInBackground();

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/RollingAverage.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/RollingAverage.java
@@ -118,17 +118,17 @@ public class RollingAverage {
         long max = -1;
         for(int i = 0; i < fill; i++) {
             if(detailedStats) {
-                stats += i + ". time=" + decFor.format(window[i] / 1000000) + " ms\n";
+                stats += i + ". time=" + decFor.format(window[i]) + " ms\n";
             }
-            if(window[i] / 1000000 < min) {
-                min = window[i] / 1000000;
+            if(window[i] < min) {
+                min = window[i];
             }
-            if(window[i] / 1000000 > max) {
-                max = window[i] / 1000000;
+            if(window[i] > max) {
+                max = window[i];
             }
         }
-        String avg = decFor.format(getAverage() / 1000000);
-        String stdDev = decFor.format(getStdDev() / 1000000);
+        String avg = decFor.format(getAverage());
+        String stdDev = decFor.format(getStdDev());
         stats += "min/avg/max/stddev = "+decFor.format(min)+"/"+avg+"/"+decFor.format(max)+"/"+stdDev+" ms";
         return stats;
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_image_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_image_processor.xml
@@ -60,7 +60,7 @@
                 android:id="@+id/network_latency"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Full Process Latency"
+                android:text="@string/full_process_latency_title"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="28sp" />
 
@@ -69,7 +69,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/network_latency"
-                android:text="Edge:"
+                android:text="@string/edge_label"
                 android:textColor="@android:color/white"
                 android:textSize="24sp" />
 
@@ -78,7 +78,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/edge_latency"
-                android:text="Stddev: 0 ms"
+                android:text="@string/stddev_label"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/network_latency"
                 android:layout_alignParentEnd="true"
-                android:text="Cloud:"
+                android:text="@string/cloud_label"
                 android:textColor="@android:color/white"
                 android:textSize="24sp" />
 
@@ -98,7 +98,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/cloud_latency"
                 android:layout_alignParentEnd="true"
-                android:text="Stddev: 0 ms"
+                android:text="@string/stddev_label"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 
@@ -114,7 +114,7 @@
                     android:id="@+id/latency_title2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Network Latency"
+                    android:text="@string/network_latency_title"
                     android:textColor="@android:color/darker_gray"
                     android:textSize="22sp" />
 
@@ -122,7 +122,7 @@
                     android:id="@+id/edge_latency2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Edge:"
+                    android:text="@string/edge_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
 
@@ -130,7 +130,7 @@
                     android:id="@+id/edge_std_dev2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Stddev: 0 ms"
+                    android:text="@string/stddev_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
             </LinearLayout>
@@ -146,7 +146,7 @@
                     android:id="@+id/cloud_latency2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Cloud:"
+                    android:text="@string/cloud_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
 
@@ -154,7 +154,7 @@
                     android:id="@+id/cloud_std_dev2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Stddev: 0 ms"
+                    android:text="@string/stddev_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
             </LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_object_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_object_processor.xml
@@ -58,7 +58,7 @@
                 android:id="@+id/full_latency"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Full Process Latency: 0 ms "
+                android:text="@string/full_process_latency_label"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="24sp" />
 
@@ -69,7 +69,7 @@
                 android:layout_below="@+id/full_latency"
                 android:layout_alignParentStart="true"
                 android:layout_marginStart="0dp"
-                android:text="Stddev: 0 ms"
+                android:text="@string/stddev_label"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 
@@ -85,7 +85,7 @@
                     android:id="@+id/network_latency"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Network Latency: 0 ms "
+                    android:text="@string/network_latency_label"
                     android:textColor="@android:color/darker_gray"
                     android:textSize="22sp" />
 
@@ -93,7 +93,7 @@
                     android:id="@+id/network_std_dev"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Stddev: 0 ms"
+                    android:text="@string/stddev_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
             </LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
@@ -58,7 +58,7 @@
                 android:id="@+id/full_latency"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Full Process Latency: 0 ms "
+                android:text="@string/full_process_latency_label"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="24sp" />
 
@@ -69,7 +69,7 @@
                 android:layout_below="@+id/full_latency"
                 android:layout_alignParentStart="true"
                 android:layout_marginStart="0dp"
-                android:text="Stddev: 0 ms"
+                android:text="@string/stddev_label"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 
@@ -85,7 +85,7 @@
                     android:id="@+id/network_latency"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Network Latency: 0 ms "
+                    android:text="@string/network_latency_label"
                     android:textColor="@android:color/darker_gray"
                     android:textSize="22sp" />
 
@@ -93,7 +93,7 @@
                     android:id="@+id/network_std_dev"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Stddev: 0 ms"
+                    android:text="@string/stddev_label"
                     android:textColor="@android:color/white"
                     android:textSize="20sp" />
             </LinearLayout>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/values/strings.xml
@@ -63,9 +63,6 @@
         <item>No. Retain current values.</item>
     </string-array>
     <string name="fd_latency_method">fd_latency_method</string>
-    <string name="preference_gpu_host_edge">fd_gpu_host_edge</string>
-    <string name="preference_gpu_host_edge_title">GPU Server (OpenPose, PyTorch)</string>
-    <string name="preference_gpu_host_edge_summary">Enter a custom IP or hostname.</string>
     <string name="train_guest_start">Start</string>
     <string name="train_guest_title">Guest Name</string>
     <string name="train_guest_message">Enter the guest name, then face recognition training will begin.</string>
@@ -78,11 +75,11 @@
     <string name="pref_latency_method">latency_method</string>
     <string name="pref_latency_method_title">Latency Test Method</string>
     <string name="pref_latency_method_summary">%s</string>
-    <string-array name="pref_latency_test_method_titles">
+    <string-array name="pref_latency_test_method_titles_cv">
         <item>System Ping (ICMP)</item>
         <item>Socket</item>
     </string-array>
-    <string-array name="pref_latency_test_method_values">
+    <string-array name="pref_latency_test_method_values_cv">
         <item>ping</item>
         <item>socket</item>
     </string-array>
@@ -101,10 +98,6 @@
         <item>WEBSOCKET</item>
     </string-array>
 
-    <string name="pref_override_gpu_cloudlet_hostname">pref_override_gpu_cloudlet_hostname</string>
-    <string name="pref_summary_override_gpu_cloudlet_hostname">Select this to enter a GPU hostname to override the FindCloudlet result.</string>
-    <string name="pref_title_override_gpu_cloudlet_hostname">Override GPU cloudlet hostname</string>
-
     <string name="pref_override_edge_cloudlet_hostname">pref_override_edge_cloudlet_hostname</string>
     <string name="pref_summary_override_edge_cloudlet_hostname">Select this to enter an Edge Server hostname to override the FindCloudlet result.</string>
     <string name="pref_title_override_edge_cloudlet_hostname">Override Edge cloudlet hostname</string>
@@ -112,5 +105,13 @@
     <string name="pref_override_cloud_cloudlet_hostname">pref_override_cloud_cloudlet_hostname</string>
     <string name="pref_summary_override_cloud_cloudlet_hostname">Select this to enter a Cloud Server hostname to override default provisioned value.</string>
     <string name="pref_title_override_cloud_cloudlet_hostname">Override Cloud cloudlet hostname</string>
+
+    <string name="network_latency_title">Network Latency</string>
+    <string name="network_latency_label">Network Latency: %d ms</string>
+    <string name="stddev_label">Stddev: %d ms</string>
+    <string name="full_process_latency_title">Full Process Latency</string>
+    <string name="full_process_latency_label">Full Process Latency: %d ms</string>
+    <string name="edge_label">Edge: %d ms</string>
+    <string name="cloud_label">Cloud: %d ms</string>
 
 </resources>

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_network.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_network.xml
@@ -17,8 +17,8 @@
         app:iconSpaceReserved="false"/>
     <ListPreference
         android:defaultValue="socket"
-        android:entries="@array/pref_latency_test_method_titles"
-        android:entryValues="@array/pref_latency_test_method_values"
+        android:entries="@array/pref_latency_test_method_titles_cv"
+        android:entryValues="@array/pref_latency_test_method_values_cv"
         android:key="@string/fd_latency_method"
         android:negativeButtonText="@null"
         android:positiveButtonText="@null"

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_overrides.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/xml/pref_overrides.xml
@@ -28,21 +28,6 @@
         android:title="@string/pref_cv_host_edge_tls_title" />
     <CheckBoxPreference
         android:defaultValue="false"
-        android:key="@string/pref_override_gpu_cloudlet_hostname"
-        android:summary="@string/pref_summary_override_gpu_cloudlet_hostname"
-        android:title="@string/pref_title_override_gpu_cloudlet_hostname"
-        app:iconSpaceReserved="false"/>
-    <EditTextPreference
-        android:defaultValue="posedetection.defaultedge.mobiledgex.net"
-        android:dependency="@string/pref_override_gpu_cloudlet_hostname"
-        android:key="@string/preference_gpu_host_edge"
-        android:selectAllOnFocus="true"
-        android:singleLine="false"
-        android:summary="@string/preference_gpu_host_edge_summary"
-        android:title="@string/preference_gpu_host_edge_title"
-        app:iconSpaceReserved="false"/>
-    <CheckBoxPreference
-        android:defaultValue="false"
         android:key="@string/pref_override_cloud_cloudlet_hostname"
         android:summary="@string/pref_summary_override_cloud_cloudlet_hostname"
         android:title="@string/pref_title_override_cloud_cloudlet_hostname"


### PR DESCRIPTION
- Renamed EdgeOnlyImageProcessorFragment to GpuImageProcessorFragment
- No more special preference for overriding GPU host. Edge host is used instead for the GPU activities.
- Got rid of useless conversions from nanoseconds to milliseconds and back again (*1000000, /1000000). Now we convert to ms when we add the measurement, and all other code expects ms values.
- Latency UI element labels now come from resource strings, and formatting is handled by resources.getString(). This allows us to specify a label format because while face detection has a "Full Process" heading and "Edge:" and "Cloud:" are where the values are actually displayed, the GPU activities have labels like "Full Process Latency:".
