### PR TITLE
AutoMigrate rework.

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 62
-        versionName "1.1.13"
+        versionName "1.1.14"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -204,7 +204,7 @@ public class MainActivity extends AppCompatActivity
 
     private String mApiKey = BuildConfig.GOOGLE_DIRECTIONS_API_KEY;
     private Polyline mRoutePolyLine;
-    private List<LatLng> mCloudletLatLngs = new ArrayList();
+    private List<LatLng> mCloudletLatLngs = new ArrayList<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -1702,7 +1702,7 @@ public class MainActivity extends AppCompatActivity
 
         Log.i(TAG, "onResume() mEdgeEventsConfigUpdated="+mEdgeEventsConfigUpdated);
         if (mEdgeEventsEnabled && mEdgeEventsConfigUpdated) {
-            meHelper.startEdgeEvents(false);
+            meHelper.startEdgeEvents();
         }
 
         startLocationUpdates();
@@ -1774,7 +1774,7 @@ public class MainActivity extends AppCompatActivity
 
             //Loop through legs and steps to get encoded polylines of each step
             for (DirectionsRoute route: calculatedRoutes.routes) {
-                List path = new ArrayList();
+                List<LatLng> path = new ArrayList<>();
 
                 if (route.legs !=null) {
                     for (int i=0; i<route.legs.length; i++) {

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,8 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "2.6.22"
+project.ext.matchingengineVersion = "3.0-rc1"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
+
+project.ext.mobiledgeXContextUrl = "https://artifactory.mobiledgex.net/artifactory"
+project.ext.debugRepoKey = "maven-development"
+project.ext.releaseRepoKey = "maven-releases"
+project.ext.repoKey = "${debugRepoKey}"
 
 //
 buildscript {
@@ -16,11 +21,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
 
         // JFrog Artifactory:
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:latest.release"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -39,42 +44,34 @@ allprojects {
     apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'maven-publish'
     repositories {
-        google()
-        mavenLocal()
-        mavenCentral()
         maven {
             credentials {
-                // Create these variables in local.properties if you don't have them.
-                username artifactory_user
-                password artifactory_password
+                // Create these variables if you don't have them.
+                username "${artifactory_user}"
+                password "${artifactory_password}"
             }
-            url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
+            url "${mobiledgeXContextUrl}/${repoKey}"
         }
-        maven { url 'https://jitpack.io' }
+        mavenLocal()
+        mavenCentral()
+        google()
     }
 }
 
 artifactory {
-    contextUrl = "https://artifactory.mobiledgex.net/"
+    contextUrl = "${mobiledgeXContextUrl}"
     publish {
         repository {
-            repoKey = 'maven-development' // The Artifactory repository key to publish to
+            repoKey = "${repoKey}" // The Artifactory repository key to publish to
             username = "${artifactory_user}" // The publisher user name
             password = "${artifactory_password}" // The publisher password
-            // This is an optional section for configuring Ivy publication (when publishIvy = true).
-            ivy {
-                ivyLayout = '[organization]/[module]/ivy-[revision].xml'
-                artifactLayout = '[organization]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]'
-                mavenCompatible = true //Convert any dots in an [organization] layout value to path separators, similar to Maven's groupId-to-path conversion. True if not specified
-            }
         }
         defaults {
             // Reference to Gradle publications defined in the build script.
             // This is how we tell the Artifactory Plugin which artifacts should be
             // published to Artifactory.
             publishArtifacts = true
-            // Properties to be attached to the published artifacts.
-            properties = ['qa.level': 'basic', 'dev.team' : 'core']
+            // Properties to be attached to the published artifacts.//
             publishPom = true // Publish generated POM files to Artifactory (true by default)
         }
     }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/res/layout/fragment_pose_processor.xml
@@ -113,7 +113,6 @@
                 android:layout_alignParentStart="true"
                 android:layout_marginStart="5dp"
                 android:scaleX="-1"
-                android:clickable="true"
                 app:srcCompat="@drawable/ic_baseline_more_24" />
 
         </RelativeLayout>

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/build.gradle
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 30
         versionCode 1
-        versionName "2.6.22"
+        versionName "${matchingengineVersion}"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
@@ -330,7 +330,9 @@ public class SettingsActivity extends AppCompatActivity implements
 
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
-            // Handled in MatchingEngineHelper.onSharedPreferenceChanged().
+            MatchingEngineHelper.mEdgeEventsConfigUpdated = true;
+            // Updating the config with changed values is handled in
+            // MatchingEngineHelper.onSharedPreferenceChanged().
         }
 
         @Override


### PR DESCRIPTION
- If AutoMigrate was set to true, any time the config was updated by preferences, the new config wasn't being used, because we weren't actually doing a startEdgeEvents(newConfig) to pass it in. Now we always to stop/start no matter the AutoMigrate setting.
- Fixed bug were changes on the "Edge Events Config" weren't setting the flag that we need to restart with a new config (`MatchingEngineHelper.mEdgeEventsConfigUpdated = true;`)
- Got rid of newConnection parameter, since we restart no matter whether the connection is new or not.