### PR TITLE
Adding waypoint support for Driving Route mode

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 62
-        versionName "1.1.14"
+        versionName "1.1.15-4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/assets/about_dialog.html
+++ b/android/MobiledgeXSDKDemo/app/src/main/assets/about_dialog.html
@@ -1,8 +1,20 @@
-<p>Version: ${androidAppVersion}</p>
+<html lang="en">
+<head>
+    <title>About Dialog</title>
+    <style>
+        body { background-color: #273C4D; }
+        p { color: White; }
+        td { color: White; }
+        a { color: #93e019; }
+        table { border: 1px solid #43809d; border-collapse: collapse; width: 100%; }
+    </style>
+</head>
+<body>
+<p>Version: <strong>${androidAppVersion}</strong></p>
 <p>This app uses the MobiledgeX Matching Engine SDK to find and display on a map all of the
  Cloudlets running the backend app that provides the speed test and computer vision services
  needed by this app. It uses the following information for the SDK API calls:</p>
-<table border="2">
+<table border="1">
     <tbody>
     <tr>
         <td><strong>appName</strong></td>
@@ -29,3 +41,5 @@
 <p>These values can be changed in the General Settings of the app.</p>
 <p>To learn more about the MobiledgeX SDK, see <a href="https://developers.mobiledgex.com/">developers.mobiledgex.com</a> for documentation and a Getting Started guide.</p>
 <p>Source code for this app is available on <a href="https://github.com/mobiledgex/edge-cloud-sampleapps/tree/master/android/MobiledgeXSDKDemo">Github</a>.</p>
+</body>
+</html>

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_route_mode.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_route_mode.xml
@@ -6,8 +6,8 @@
     <SeekBarPreference
         app:key="pref_driving_time_seekbar"
         android:title="@string/pref_title_driving_time"
-        android:defaultValue="18"
-        android:max="30"
+        android:defaultValue="20"
+        android:max="60"
         android:min="1"
         android:icon="@drawable/ic_pref_driving"
         app:showSeekBarValue="true"
@@ -16,8 +16,8 @@
     <SeekBarPreference
         app:key="pref_flying_time_seekbar"
         android:title="@string/pref_title_flying_time"
-        android:defaultValue="12"
-        android:max="30"
+        android:defaultValue="15"
+        android:max="60"
         android:min="1"
         android:icon="@drawable/ic_pref_flying"
         app:showSeekBarValue="true"

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0-rc1-i"
+project.ext.matchingengineVersion = "3.0-rc2-rebuild"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/values/strings.xml
@@ -51,6 +51,9 @@
     <string name="pref_net_switching_allowed">net_switching_allowed</string>
     <string name="pref_net_switching_allowed_title">Network Switching Enabled</string>
     <string name="pref_net_switching_allowed_summary">Wifi to Cell network switching</string>
+    <string name="pref_use_wifi_only">use_wifi_only</string>
+    <string name="pref_use_wifi_only_title">Use Wifi Only</string>
+    <string name="pref_use_wifi_only_summary">Disables using the mobile network</string>
 
     <string name="pref_find_cloudlet_mode">find_cloudlet_mode</string>
     <string name="pref_find_cloudlet_mode_title">FindCloudlet Mode</string>

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_matching_engine.xml
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_matching_engine.xml
@@ -21,6 +21,14 @@
         android:summary="@string/pref_net_switching_allowed_summary"
         android:title="@string/pref_net_switching_allowed_title"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:id="@+id/preference_use_wifi_only"
+        android:contentDescription="preference_use_wifi_only"
+        android:defaultValue="false"
+        android:key="@string/pref_use_wifi_only"
+        android:summary="@string/pref_use_wifi_only_summary"
+        android:title="@string/pref_use_wifi_only_title"
+        app:iconSpaceReserved="false" />
     <ListPreference
         android:defaultValue="PROXIMITY"
         android:entries="@array/pref_find_cloudlet_mode_titles"


### PR DESCRIPTION
- Added "Use Wifi Only" setting. If value is false, carrierName comes from prefs. If true, carrierName comes from me.getCarrierName(), which currently is "" for the wifi-only case.
- Remove hard-coded 8008 from Cloudlet.java latency test code, and EVENT_LATENCY_REQUEST handling code. Use port info returned by the DME.
- Added CSS to "About" HTML to the use MobiledgeX colors instead of stark black and white.
- To add a waypoint, after driving route created, long-press on map, and select "Add waypoint to route".
- Individual waypoints can be dragged and dropped just like the start and end markers.
- New defaults/max values for animation times.
- Bug fixes when switching between driving and flying route modes.
