### PR TITLE
EDGECLOUD-5537 EDGECLOUD-5563 EDGECLOUD-5414

### DIFF
--- a/android/MobiledgeXSDKDemo/README.md
+++ b/android/MobiledgeXSDKDemo/README.md
@@ -5,94 +5,17 @@
 - Allows calling individual MobiledgeX APIs:
     - Register Client
     - Get App Instances
-    - Verify Location
     - Find Closest Cloudlet
 - Cloudlet Latency Test
 - Cloudlet Download Speed Test
 - Cloudlet Upload Speed Test
-- GPS Spoofing Demo (see below)
-- Face Detection
-- Face Recognition
-- Pose Detection
-- Predictive Quality of Service
+- GPS Spoofing Demo
+- Edge Events Config Editor (Settings)
+- Route Mode for demonstrating Edge Events
+- Computer Vision Demos
+    - Face Detection
+    - Face Recognition
+    - Pose Detection
+    - Object Detection
 
-### Cloudlet Map
-The app's startup page is a world map showing MobiledgeX cloudlets where the app's backend is running. If no cloudlets are shown, or you don't see the set cloudlets you expect to see, click the main menu "hamburger" icon and select **Settings**, then **General Settings**. From here, select the **Region** and **Operator Name** you're interested in.
-
-Tap on any of the cloudlets, and a panel with the cloudlet's name will appear. On that panel, you can "click for details" to see cloudlet information like latitude, longitude, and distance from your location.
-
-#### Cloudlet Details
-In addition to showing the details of the cloudlet, this page allows the initiation of a latency test or download/upload speed tests. The settings of this page allow control of certain conditions, such as the number of packets for the latency test, or the size of the download. Click the "Gear" icon to access these settings.
-
-You can also choose this cloudlet to be used as the **Edge** server for Face Detection and Face Recognition. Tap the 3-dot menu and select "Use as Face Recognition Edge Host". The **Cloud** server can be configured in the same way.
-
-### SDK Calls
-#### Register Client
-This will call the [RegisterClientAPI](https://
-.mobiledgex.net/#section/Edge-SDK-Android/RegisterClient "RegisterClient") with information that identifies this app's backend software. The session cookie is shown to verify that the call was successful.
-
-#### Get App Instances
-This will call the GetAppInstListAPI to find everywhere our backend is running, and will draw a cloudlet icon for every location found.
-
-#### Verify Location
-This will call the [VerifyLocationAPI](https://swagger.mobiledgex.net/#section/Edge-SDK-Android/VerifyLocation "VerifyLocation") with our current GPS coordinates to verify that the mobile device is where it claims to be. If successful, the mobile phone icon is green showing the accuracy information briefly. If location verification fails, the icon will be red, displaying the result code temporarily. Tapping the icon will show the result code of the call.
-
-#### Find Closest Cloudlet
-This will call the [FindCloudletAPI](https://swagger.mobiledgex.net/#section/Edge-SDK-Android/FindCloudlet "FindCloudlet") with our current GPS coordinates to determine which cloudlet running our backend is the closest. That cloudlet icon will turn green, and a line will be drawn between it and our location.
-
-#### Perform All
-Select the red button in the lower right to perform all of these API calls in succession.
-
-### GPS Spoofing Demo
-The app uses the MobiledgeX [VerifyLocationAPI](https://swagger.mobiledgex.net/#section/Edge-SDK-Android/VerifyLocation "VerifyLocation") to verify that the GPS coordinates reported are where the device actually is. 
-
-When you start the app, you will see your location on the map represented by a mobile phone icon. 
-
-In the real world, location verification is implemented by the cellular network operator. For this demo, we use a simulator that stores location data and is keyed on your current public IP address. To get an initial entry in the simulator database, tap the 3-dot menu, and select "Reset Location." Now the simulator considers the valid location to be wherever your current GPS coordinates are. If your IP address stays the same, you won't need to repeat this step next time you run the app.
-
-You can move the mobile phone icon by long-pressing on it and dragging it to a new location, or long-pressing anywhere on the map. When you release the icon, you will be presented with two options:
-- Spoof GPS at this location
-- Update location in GPS database.
-
-If you select "Spoof," this new location will be used for subsequent **Find Closest Cloudlet** and **Verify Location** calls. Depending on how close the location stored in the simulator is, your next **Verify Location** call may return a different "accuracy" value, or return a failure. Tapping the mobile phone icon will display the distance from the actual location, and any result code available.
-
-If you select "Update location," this new location will be sent to the location simulator and will be used until another location is sent, or "Reset Location" is performed. Reset Location allows you to simulate your real location to be anywhere in the world, and you can verify that **Find Closest Cloudlet** finds the expected cloudlet.
-
-### Computer Vision Demos
-Select one of the **Detection** or **Recognition** activities from the main menu. You can control several options, like which stats are displayed by selecting the "gear" icon to access **Computer Vision Settings**. 
-
-Things to try:
-- You may switch between the front and rear camera by tapping the camera icon.
-- Tap the 3-dot menu, and select "Play Video" to process a canned video instead of images from the camera. This function is useful for unattended demos or benchmarking.
-- Go to settings and turn on "Show Latency Stats after session" to get a stats summary that can be copy/pasted for additional use.
-
-#### Face Detection
-The Face Detection activity provides a visual comparison of the latency offered by an Edge cloudlet vs. that of a server in the public cloud. The Edge cloudlet can be determined in a few ways, in this order of priority:
-1. The result of "Find Closest Cloudlet", if performed.
-1. Selected from within the Cloudlet Details page options menu. This also activates the "Override Edge cloudlet hostname" value in **Computer Vision Settings**.
-1. "Edge Server" entry in the **Computer Vision Settings**, if updated by the user.
-1. The default hostname from the provisioning data at http://opencv.facetraining.mobiledgex.net/cvprovisioning.json.
-
-Images from the camera are sent to a server that uses OpenCV to detect faces in the image. The server returns coordinates of any faces, and the app renders rectangles around them. 
-
-#### Face Recognition
-Face Recognition is similar, but instead of only detecting the presence of a face in an image, the name of the subject will also be returned if the person is part of the training data. To add your face to the training data, tap the 3-dot menu, and select "Training Mode." You must be signed in to your Google account via the main menu so that your name can be associated with the face images. "Guest Training Mode" is also available to add images of another person, whose name you must enter. You own your images and any guest images you add, and you can remove them at any time, by selecting the appropriate menu entry.
-
-Note that for Recognition, only a single face is supported at a time. If more than one face appears in the given image, only one of them will be detected and recognized.
-
-#### Pose Detection
-Pose Detection uses OpenPose on a GPU-enabled cloudlet to detect the pose of human bodies. Like the other activities, images from the camera are sent to the cloudlet for processing. Instead of rectangular coordinates, points representing the bones of the pose(s) are received and rendered.
-
-There is no Edge/Cloud comparison for this activity. A single cloudlet is used for image processing.
-
-Note that Pose Detection does not use the result of "Find Closest Cloudlet" because there are a limited number of GPU-enabled cloudlets available.
-
-### Predictive Quality of Service
-This activity shows a map with two endpoints. The beginning and ending locations can be dragged around on the map to change the routes shown. PQoS data is retrieved for each point along the routes and is displayed in a color-coded style.
-
-You can change the Date and Time of the predicted data by tapping the appropriate button. There are also menu entries to change the point mode (Route or Grid) and to change the map type. There is also support to load a CSV file containing position data to be rendered. For details, see Menu > CSV File > CVS File Help.
-
-Currently, PQoS data is available only in Germany.
-
-
-
+For more details, see [MobiledgeX Android Demo App](https://developers.mobiledgex.com/product/mobiledgex-demo/).

--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 62
-        versionName "1.1.16"
+        versionCode 63
+        versionName "1.1.17"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]
@@ -21,6 +21,12 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        // Flag to enable support for the new language APIs
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
         exclude 'META-INF/INDEX.LIST'
@@ -83,6 +89,7 @@ dependencies {
     implementation 'javax.annotation:javax.annotation-api:1.2'
     implementation project(path: ':computervision')
     implementation project(path: ':matchingenginehelper')
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
 }
 

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -96,6 +96,7 @@ public class Cloudlet implements Serializable {
     private CloudletListHolder.LatencyTestMethod mLatencyTestMethod;
     private boolean mLatencyTestMethodForced = false;
     private Context mContext;
+    private boolean mRemoved;
 
     public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, String fqdnPrefix, boolean tls, Marker marker, int port) {
         Log.d(TAG, "Cloudlet contructor. cloudletName="+cloudletName);
@@ -260,6 +261,14 @@ public class Cloudlet implements Serializable {
 
     public void setContext(Context context) {
         mContext = context;
+    }
+
+    public void setRemoved(boolean removed) {
+        this.mRemoved = removed;
+    }
+
+    public boolean isRemoved() {
+        return mRemoved;
     }
 
     public class LatencyTestTaskSocket extends AsyncTask<Void, Integer, String> {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -598,6 +598,11 @@ public class MainActivity extends AppCompatActivity
         mapTypeGroupPrevItem.setChecked(true);
         onMapTypeGroupItemClick(mapTypeGroupPrevItem);
         Log.i(TAG, "onCreateOptionsMenu itemId="+itemId+" "+mapTypeGroupPrevItem);
+
+        // TODO: If we want to allow verifyLocation, unhide this menu item.
+        MenuItem verifyLocationMenuItem = menu.findItem(R.id.action_verify_location);
+        verifyLocationMenuItem.setVisible(false);
+
         return true;
     }
 
@@ -1345,10 +1350,6 @@ public class MainActivity extends AppCompatActivity
         Cloudlet cloudlet = null;
         meHelper.mClosestCloudlet = null;
         Log.d(TAG, "Existing CloudletList: "+CloudletListHolder.getCloudletList());
-
-
-
-
         for (int i = 0; i < CloudletListHolder.getCloudletList().size(); i++) {
             cloudlet = CloudletListHolder.getCloudletList().valueAt(i);
             Log.i(TAG, "Checking: "+closestCloudlet.getFqdn()+" "+cloudlet.getFqdn());
@@ -1936,10 +1937,8 @@ public class MainActivity extends AppCompatActivity
                     }
                 }
 
-                // TODO:
                 // Reduce the number of points in the path.
                 List<LatLng> reducedPath = new ArrayList<>();
-
                 for (LatLng latLng : path) {
                     numPoints++;
                     if (numPoints % mRoutePointModulo == 0) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -120,6 +120,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -200,8 +201,10 @@ public class MainActivity extends AppCompatActivity
     private ValueAnimator mValueAnimator;
     private int mDrivingAnimDuration;
     private int mFlyingAnimDuration;
+    private int mRoutePointModulo;
     private static final int DEF_DRIVING_DURATION = 20; //Seconds
     private static final int DEF_FLYING_DURATION = 15; //Seconds
+    private static final int DEF_ROUTE_POINT_REDUCTION = 10;
 
     private String mApiKey = BuildConfig.GOOGLE_DIRECTIONS_API_KEY;
     private Polyline mRoutePolyLine;
@@ -284,6 +287,7 @@ public class MainActivity extends AppCompatActivity
         fabPlayRoute.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                Log.d(TAG, "Play route button pressed");
                 playRoute();
             }
         });
@@ -323,6 +327,7 @@ public class MainActivity extends AppCompatActivity
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_latency_autostart));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_driving_time_seekbar));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_flying_time_seekbar));
+        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_route_point_reduction_seekbar));
 
         // Watch for any updated preferences:
         prefs.registerOnSharedPreferenceChangeListener(this);
@@ -341,12 +346,9 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void playRoute() {
-        Log.i(TAG, "playRoute mRouteIsPlaying="+mRouteIsPlaying);
+        Log.i(TAG, "playRoute mRouteIsPlaying="+mRouteIsPlaying+" mRouteMode="+mRouteMode);
         if (mRouteIsPlaying) {
             fabPlayRoute.setImageResource(R.drawable.ic_baseline_play_arrow_24);
-            if (mValueAnimator != null) {
-                mValueAnimator.cancel();
-            }
             mRouteIsPlaying = false;
         } else {
             fabPlayRoute.setImageResource(R.drawable.ic_baseline_pause_24);
@@ -368,6 +370,8 @@ public class MainActivity extends AppCompatActivity
      * @param duration Animation duration in ms.
      */
     public void animateMarker(RouteMode routeMode, Marker marker, LatLng endPosition, long duration) {
+        Log.i(TAG, "animateMarker routeMode="+routeMode+" duration="+duration);
+
         final long[] lastLocationUpdateTime = {0};
         LatLng startPosition = marker.getPosition();
 
@@ -376,11 +380,30 @@ public class MainActivity extends AppCompatActivity
         mValueAnimator.setDuration(duration);
         mValueAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
         mValueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            private long mFrameLastTime;
+            private long mFrameStartTime;
+            private int mFrameCount;
+            private DecimalFormat decFor = new DecimalFormat("#.###");
+
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {
                 float v = animation.getAnimatedFraction();
+                mFrameCount++;
+                long current = System.currentTimeMillis();
+                if(mFrameStartTime == 0) {
+                    mFrameStartTime = current;
+                }
+                long totalSeconds = (current - mFrameStartTime)/1000;
+                if(mFrameLastTime > 0) {
+                    Log.i(TAG, "elapsed="+(current - mFrameLastTime)+" FPS="+(decFor.format((float) mFrameCount /totalSeconds)));
+                }
+                mFrameLastTime = current;
+
                 LatLng newPosition;
                 if (routeMode == RouteMode.DRIVING) {
+                    if (mRoutePolyLine == null) {
+                        return;
+                    }
                     int index = (int) (v * mRoutePolyLine.getPoints().size());
                     if (index >= mRoutePolyLine.getPoints().size()) {
                         return;
@@ -415,6 +438,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     protected void drawClosestCloudletLine() {
+        Log.i(TAG, "drawClosestCloudletLine. getClosestCloudletPosition()="+getClosestCloudletPosition());
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -589,7 +613,7 @@ public class MainActivity extends AppCompatActivity
             meHelper.registerClientInBackground();
         }
         if (id == R.id.action_get_app_inst_list) {
-            getCloudlets(false);
+            getCloudlets(true);
         }
         if (id == R.id.action_reset_location) {
             // Reset spoofed GPS
@@ -612,7 +636,6 @@ public class MainActivity extends AppCompatActivity
             if(meHelper.mAllowLocationSimulatorUpdate) {
                 updateLocSimLocation(lastKnownLocation.getLatitude(), lastKnownLocation.getLongitude());
             }
-            meHelper.mClosestCloudletHostname = null;
             getCloudlets(true);
             return true;
         }
@@ -655,7 +678,7 @@ public class MainActivity extends AppCompatActivity
         } else if (id == R.id.nav_face_detection) {
             // Start the face detection Activity
             Intent intent = new Intent(this, ImageProcessorActivity.class);
-            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, meHelper.mClosestCloudletHostname);
+            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, meHelper.getClosestCloudletHostname());
             putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
@@ -663,7 +686,7 @@ public class MainActivity extends AppCompatActivity
             // Start the face recognition Activity
             Intent intent = new Intent(this, ImageProcessorActivity.class);
             intent.putExtra(ImageProcessorFragment.EXTRA_FACE_RECOGNITION, true);
-            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, meHelper.mClosestCloudletHostname);
+            intent.putExtra(ImageProcessorFragment.EXTRA_EDGE_CLOUDLET_HOSTNAME, meHelper.getClosestCloudletHostname());
             putCommonIntentExtras(intent);
             startActivityForResult(intent, RC_STATS);
             return true;
@@ -723,6 +746,9 @@ public class MainActivity extends AppCompatActivity
 
         // Turn off everything route related. If a menu item is being unchecked,
         // then we're done after this. Otherwise we will rebuild everything below.
+        if (mValueAnimator != null) {
+            mValueAnimator.cancel();
+        }
         if (mStartMarker != null) {
             mStartMarker.setVisible(false);
         }
@@ -741,6 +767,7 @@ public class MainActivity extends AppCompatActivity
         if (item.isChecked()) {
             if (routeModePrevItem == item) {
                 routeModePrevItem.setChecked(false);
+                mRoutePolyLine = null;
                 return;
             }
         }
@@ -751,6 +778,7 @@ public class MainActivity extends AppCompatActivity
 
         if (item.getItemId() == R.id.action_route_mode_flying) {
             mRouteMode = RouteMode.FLYING;
+            mRoutePolyLine = null;
             initRouteMarkers(item.getItemId());
             item.setChecked(true);
             fabPlayRoute.setVisibility(View.VISIBLE);
@@ -986,12 +1014,9 @@ public class MainActivity extends AppCompatActivity
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    //Clear list so we don't show old cloudlets as transparent
                     //First, remove all cloudlet markers.
-                    for (int i = 0; i < CloudletListHolder.getCloudletList().size(); i++) {
-                        Cloudlet cloudlet = CloudletListHolder.getCloudletList().valueAt(i);
-                        cloudlet.getMarker().remove();
-                    }
+                    mGoogleMap.clear();
+                    mUserLocationMarker = null; // Will be recreated.
                     //Then clear the list.
                     CloudletListHolder.getCloudletList().clear();
                 }
@@ -1020,7 +1045,7 @@ public class MainActivity extends AppCompatActivity
             tls = false;
         }
         String scheme = tls ? "https" : "http";
-        String appInstUrl = scheme+"://"+meHelper.mClosestCloudlet.getFqdn()+":"+testConnectionPort+testUrl;
+        String appInstUrl = scheme+"://"+meHelper.getClosestCloudletHostname()+":"+testConnectionPort+testUrl;
 
         return new ConnectionTester(appInstUrl, expectedResponse);
     }
@@ -1205,15 +1230,26 @@ public class MainActivity extends AppCompatActivity
      * @param cloudlet
      */
     private void initCloudletMarker(Cloudlet cloudlet) {
+        Log.i(TAG, "initCloudletMarker "+cloudlet);
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 Marker marker = cloudlet.getMarker();
                 String cloudletName = cloudlet.getCloudletName();
-                marker.setTitle(cloudletName + " Cloudlet");
-                marker.setSnippet("Click for details");
+                marker.setTitle(cloudletName);
+                if (cloudlet.isRemoved()) {
+                    marker.setSnippet("Has been removed");
+                } else {
+                    marker.setSnippet("Click for details");
+                }
                 marker.setTag(cloudletName); // This is used by automation testing.
-                marker.setIcon(makeMarker(R.mipmap.ic_marker_cloudlet, mDefaultCloudletColor, getBadgeText(cloudlet)));
+                int color = mDefaultCloudletColor;
+                if (meHelper.mClosestCloudlet != null &&
+                        meHelper.mClosestCloudlet.getFqdn().equals(cloudlet.getFqdn())) {
+                    cloudlet.setBestMatch(true);
+                    color = COLOR_VERIFIED;
+                }
+                marker.setIcon(makeMarker(R.mipmap.ic_marker_cloudlet, color, getBadgeText(cloudlet)));
             }
         });
     }
@@ -1302,10 +1338,17 @@ public class MainActivity extends AppCompatActivity
      */
     @Override
     public void onFindCloudlet(final AppClient.FindCloudletReply closestCloudlet) {
+        Log.i(TAG, "onFindCloudlet "+closestCloudlet.getFqdn());
         // Get full list of cloudlets again in case any have been added or removed.
         getCloudlets(false);
         initAllCloudletMarkers();
         Cloudlet cloudlet = null;
+        meHelper.mClosestCloudlet = null;
+        Log.d(TAG, "Existing CloudletList: "+CloudletListHolder.getCloudletList());
+
+
+
+
         for (int i = 0; i < CloudletListHolder.getCloudletList().size(); i++) {
             cloudlet = CloudletListHolder.getCloudletList().valueAt(i);
             Log.i(TAG, "Checking: "+closestCloudlet.getFqdn()+" "+cloudlet.getFqdn());
@@ -1319,17 +1362,25 @@ public class MainActivity extends AppCompatActivity
                         marker.setIcon(makeMarker(R.mipmap.ic_marker_cloudlet, COLOR_VERIFIED, badgeText));
                     }
                 });
+                meHelper.mClosestCloudlet = closestCloudlet;
                 cloudlet.setBestMatch(true);
                 break;
             }
         }
-        if (cloudlet != null) {
-            drawClosestCloudletLine();
-            //Save the hostname for use by the Computer Vision Activity.
-            meHelper.mClosestCloudletHostname = cloudlet.getHostName();
-            Log.i(TAG, "mClosestCloudletHostname: "+ meHelper.mClosestCloudletHostname);
-            showMessage("Closest Cloudlet is now: " + meHelper.mClosestCloudletHostname);
+        if (meHelper.mClosestCloudlet == null) {
+            meHelper.mClosestCloudlet = closestCloudlet;
+            Log.i(TAG, "onFindCloudlet. No existing cloudlet found for "+closestCloudlet.getFqdn());
+            String message = "New cloudlet received, now closest: "+meHelper.getClosestCloudletHostname();
+            Log.i(TAG, message);
+            showMessage(message);
+//            CloudletListHolder.getCloudletList().put(closestCloudlet.get)
+        } else {
+            String message = "Closest Cloudlet is now: " + meHelper.getClosestCloudletHostname();
+            Log.i(TAG, message);
+            showMessage(message);
         }
+
+        drawClosestCloudletLine();
     }
 
     /**
@@ -1366,12 +1417,16 @@ public class MainActivity extends AppCompatActivity
                     showError(message);
                 }
 
-                showMessage("Got "+cloudletList.getCloudletsList().size()+" cloudlets");
+                String message = "Got "+cloudletList.getCloudletsList().size()+" cloudlets";
+                Log.i(TAG, message);
+                showMessage(message);
                 int num = 1;
                 //First get the new list into an ArrayMap so we can index on the cloudletName
                 for(AppClient.CloudletLocation cloudletLocation : cloudletList.getCloudletsList()) {
                     Log.i(TAG, "getCloudletName()="+cloudletLocation.getCloudletName()+" getCarrierName()="+cloudletLocation.getCarrierName());
-                    showMessage(" "+num+". "+cloudletLocation.getCloudletName());
+                    message = " "+num+". "+cloudletLocation.getCloudletName();
+                    Log.i(TAG, message);
+                    showMessage(message);
                     num++;
                     Cloudlet cloudlet = makeCloudlet(cloudletLocation);
                     tempCloudlets.put(cloudlet.getCloudletName(), cloudlet);
@@ -1392,11 +1447,14 @@ public class MainActivity extends AppCompatActivity
                         Log.i(TAG, cloudlet.getCloudletName() + " has been removed");
                         showMessage(cloudlet.getCloudletName() + " has been removed");
                         Marker marker = cloudlet.getMarker();
+                        cloudlet.setRemoved(true);
+                        marker.hideInfoWindow();
                         marker.setSnippet("Has been removed");
                         marker.setIcon(makeMarker(R.mipmap.ic_marker_cloudlet, COLOR_FAILURE, getBadgeText(cloudlet)));
                         marker.setAlpha((float) 0.33);
                     }
                 }
+                Log.i(TAG, "tempCloudlets="+tempCloudlets);
                 CloudletListHolder.setCloudlets(tempCloudlets);
 
                 // Erase "closest cloudlet" line if it exists.
@@ -1446,6 +1504,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     protected Cloudlet makeCloudlet(AppClient.CloudletLocation cloudletLocation) {
+        Log.i(TAG, "makeCloudlet "+cloudletLocation.getCloudletName());
         String carrierName = cloudletLocation.getCarrierName();
         String cloudletName = cloudletLocation.getCloudletName();
         List<AppClient.Appinstance> appInstances = cloudletLocation.getAppinstancesList();
@@ -1530,6 +1589,10 @@ public class MainActivity extends AppCompatActivity
 
         String cloudletName = (String) marker.getTag();
         Cloudlet cloudlet = CloudletListHolder.getCloudletList().get(cloudletName);
+        if (cloudlet == null) {
+            Log.d(TAG, "skipping removed cloudlet "+cloudletName);
+            return;
+        }
         Log.i(TAG, "1."+cloudlet+" "+cloudlet.getCloudletName()+" "+cloudlet.getSpeedTestDownloadResult());
 
         Intent intent = new Intent(getApplicationContext(), CloudletDetailsActivity.class);
@@ -1678,45 +1741,55 @@ public class MainActivity extends AppCompatActivity
         String prefKeyLatencyMethod = getResources().getString(R.string.pref_latency_method);
         String prefKeyLatencyAutoStart = getResources().getString(R.string.pref_latency_autostart);
         String prefKeyDrivingAnimDuration = getResources().getString(R.string.pref_driving_time_seekbar);
+        String prefKeyRoutePointReduction = getResources().getString(R.string.pref_route_point_reduction_seekbar);
         String prefKeyFlyingAnimDuration = getResources().getString(R.string.pref_flying_time_seekbar);
 
         if (key.equals(prefKeyLatencyMethod)) {
-            String latencyTestMethod = sharedPreferences.getString(prefKeyLatencyMethod, defaultLatencyMethod);
+            String latencyTestMethod = sharedPreferences.getString(key, defaultLatencyMethod);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+latencyTestMethod);
             CloudletListHolder.setLatencyTestMethod(latencyTestMethod);
         }
 
         if (key.equals(prefKeyLatencyAutoStart)) {
-            boolean latencyTestAutoStart = sharedPreferences.getBoolean(prefKeyLatencyAutoStart, true);
+            boolean latencyTestAutoStart = sharedPreferences.getBoolean(key, true);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+latencyTestAutoStart);
             CloudletListHolder.setLatencyTestAutoStart(latencyTestAutoStart);
         }
 
         if (key.equals(prefKeyDownloadSize)) {
-            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyDownloadSize, "10485760"));
+            int numBytes = Integer.parseInt(sharedPreferences.getString(key, "10485760"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
             CloudletListHolder.setNumBytesDownload(numBytes);
         }
 
         if (key.equals(prefKeyUploadSize)) {
-            int numBytes = Integer.parseInt(sharedPreferences.getString(prefKeyUploadSize, "5242880"));
+            int numBytes = Integer.parseInt(sharedPreferences.getString(key, "5242880"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numBytes);
             CloudletListHolder.setNumBytesUpload(numBytes);
         }
 
         if (key.equals(prefKeyNumPackets)) {
-            int numPackets = Integer.parseInt(sharedPreferences.getString(prefKeyNumPackets, "5"));
+            int numPackets = Integer.parseInt(sharedPreferences.getString(key, "5"));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+numPackets);
             CloudletListHolder.setNumPackets(numPackets);
         }
 
         if (key.equals(prefKeyDrivingAnimDuration)) {
-            mDrivingAnimDuration = 1000 * sharedPreferences.getInt(prefKeyDrivingAnimDuration, DEF_DRIVING_DURATION);
+            mDrivingAnimDuration = 1000 * sharedPreferences.getInt(key, DEF_DRIVING_DURATION);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mDrivingAnimDuration);
         }
 
+        if (key.equals(prefKeyRoutePointReduction)) {
+            mRoutePointModulo = sharedPreferences.getInt(key, DEF_ROUTE_POINT_REDUCTION);
+            Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mRoutePointModulo);
+            if (mRoutePointModulo == 0) {
+                mRoutePointModulo = 1;
+            }
+            Log.i(TAG, "onSharedPreferenceChanged("+key+"). mRoutePointModulo="+mRoutePointModulo);
+        }
+
         if (key.equals(prefKeyFlyingAnimDuration)) {
-            mFlyingAnimDuration = 1000 * sharedPreferences.getInt(prefKeyFlyingAnimDuration, DEF_FLYING_DURATION);
+            mFlyingAnimDuration = 1000 * sharedPreferences.getInt(key, DEF_FLYING_DURATION);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mFlyingAnimDuration);
         }
     }
@@ -1789,6 +1862,9 @@ public class MainActivity extends AppCompatActivity
      * @param waypointMarkers  List of Waypoint markers to added to the route.
      */
     private void routeBetweenPoints(LatLng startLatLng, LatLng endLatLng, List<Marker> waypointMarkers) {
+        Log.i(TAG, "routeBetweenPoints with "+waypointMarkers.size()+" waypoint(s)");
+        long start = System.currentTimeMillis();
+
         LatLngBounds.Builder boundsBuilder = new LatLngBounds.Builder();
 
         //Execute Directions API request
@@ -1824,6 +1900,7 @@ public class MainActivity extends AppCompatActivity
             Log.d(TAG, "calculatedRoutes="+calculatedRoutes.routes.length);
             fabPlayRoute.setVisibility(View.VISIBLE);
 
+            int numPoints = 0;
             //Loop through legs and steps to get encoded polylines of each step
             for (DirectionsRoute route: calculatedRoutes.routes) {
                 List<LatLng> path = new ArrayList<>();
@@ -1843,7 +1920,6 @@ public class MainActivity extends AppCompatActivity
                                         for (com.google.maps.model.LatLng coord : coords) {
                                             LatLng latLng = new LatLng(coord.lat, coord.lng);
                                             path.add(latLng);
-                                            boundsBuilder.include(latLng);
                                         }
                                     }
                                 } else {
@@ -1853,18 +1929,32 @@ public class MainActivity extends AppCompatActivity
                                     for (com.google.maps.model.LatLng coord : coords) {
                                         LatLng latLng = new LatLng(coord.lat, coord.lng);
                                         path.add(latLng);
-                                        boundsBuilder.include(latLng);
                                     }
                                 }
                             }
                         }
                     }
                 }
-                Log.d(TAG, "path.size()="+path.size());
+
+                // TODO:
+                // Reduce the number of points in the path.
+                List<LatLng> reducedPath = new ArrayList<>();
+
+                for (LatLng latLng : path) {
+                    numPoints++;
+                    if (numPoints % mRoutePointModulo == 0) {
+                        reducedPath.add(latLng);
+                        boundsBuilder.include(latLng);
+                    }
+                }
+
+                long elapsed = System.currentTimeMillis() - start;
+                float percent = 100f / mRoutePointModulo;
+                Log.d(TAG, elapsed+" ms to generate path.size()="+path.size()+ ". Kept every "+ mRoutePointModulo +"th value, reduced to "+percent+"%");
 
                 //Draw the polyline
                 if (path.size() > 0) {
-                    PolylineOptions opts = new PolylineOptions().addAll(path).color(Color.BLUE).width(8);
+                    PolylineOptions opts = new PolylineOptions().addAll(reducedPath).color(Color.BLUE).width(8);
                     mRoutePolyLine = mGoogleMap.addPolyline(opts);
                 }
             }
@@ -1876,7 +1966,7 @@ public class MainActivity extends AppCompatActivity
             LatLngBounds bounds = boundsBuilder.build();
             int width = getResources().getDisplayMetrics().widthPixels;
             int height = getResources().getDisplayMetrics().heightPixels;
-            int padding = (int) (height * 0.10); // offset from edges of the map 10% of screen
+            int padding = (int) (height * 0.01); // offset from edges of the map 1% of screen
             CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, width, height, padding);
             mGoogleMap.animateCamera(cu);
 

--- a/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/values/strings.xml
@@ -63,8 +63,11 @@
 
     <!-- Settings for Route Mode -->
     <string name="pref_title_driving_time">Driving Animation Time (Seconds)</string>
-    <string name="pref_title_flying_time">Flying Animation Time (Seconds)</string>
     <string name="pref_driving_time_seekbar">pref_driving_time_seekbar</string>
+    <string name="pref_title_route_point_reduction">Route Points Reduction</string>
+    <string name="pref_route_point_reduction_seekbar">pref_route_point_reduction_seekbar</string>
+    <string name="pref_summary_route_point_reduction">Modulo value for adding points to route, i.e. keep every Nth value</string>
+    <string name="pref_title_flying_time">Flying Animation Time (Seconds)</string>
     <string name="pref_flying_time_seekbar">pref_flying_time_seekbar</string>
 
     <!-- Strings related to first-use screen -->

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_route_mode.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_route_mode.xml
@@ -3,24 +3,37 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <SeekBarPreference
-        app:key="pref_driving_time_seekbar"
-        android:title="@string/pref_title_driving_time"
-        android:defaultValue="20"
-        android:max="60"
-        android:min="1"
-        android:icon="@drawable/ic_pref_driving"
-        app:showSeekBarValue="true"
-        />
+    <PreferenceCategory android:title="Driving">
 
-    <SeekBarPreference
-        app:key="pref_flying_time_seekbar"
-        android:title="@string/pref_title_flying_time"
-        android:defaultValue="15"
-        android:max="60"
-        android:min="1"
-        android:icon="@drawable/ic_pref_flying"
-        app:showSeekBarValue="true"
-        />
+        <SeekBarPreference
+            android:defaultValue="20"
+            android:icon="@drawable/ic_pref_driving"
+            android:max="60"
+            android:min="1"
+            android:title="@string/pref_title_driving_time"
+            app:key="pref_driving_time_seekbar"
+            app:showSeekBarValue="true" />
+        <SeekBarPreference
+            android:defaultValue="10"
+            android:max="100"
+            android:min="1"
+            android:summary="@string/pref_summary_route_point_reduction"
+            android:title="@string/pref_title_route_point_reduction"
+            app:key="@string/pref_route_point_reduction_seekbar"
+            app:seekBarIncrement="10"
+            app:showSeekBarValue="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Flying">
+
+        <SeekBarPreference
+            android:defaultValue="15"
+            android:icon="@drawable/ic_pref_flying"
+            android:max="60"
+            android:min="1"
+            android:title="@string/pref_title_flying_time"
+            app:key="pref_flying_time_seekbar"
+            app:showSeekBarValue="true" />
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0-rc3"
+project.ext.matchingengineVersion = "3.0"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
 

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0-rc2-rebuild"
+project.ext.matchingengineVersion = "3.0-rc3"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
 
 project.ext.mobiledgeXContextUrl = "https://artifactory.mobiledgex.net/artifactory"
 project.ext.debugRepoKey = "maven-development"
 project.ext.releaseRepoKey = "maven-releases"
-project.ext.repoKey = "${debugRepoKey}"
+project.ext.repoKey = "${releaseRepoKey}"
 
 //
 buildscript {

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/Camera2BasicFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/Camera2BasicFragment.java
@@ -274,9 +274,9 @@ public class Camera2BasicFragment extends Fragment
             if(mFrameStartTime == 0) {
                 mFrameStartTime = now;
             }
-            long totalSeconds = (now- mFrameStartTime)/1000;
+            long totalSeconds = (now - mFrameStartTime)/1000;
             if(mFrameLastTime > 0) {
-                Log.i(TAG, "elapsed="+(now- mFrameLastTime)+" FPS="+(decFor.format((float) mFrameCount /totalSeconds)));
+                Log.i(TAG, "elapsed="+(now - mFrameLastTime)+" FPS="+(decFor.format((float) mFrameCount /totalSeconds)));
             }
             mFrameLastTime = now;
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/EventLogViewer.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/EventLogViewer.java
@@ -137,7 +137,7 @@ public class EventLogViewer implements PopupMenu.OnMenuItemClickListener {
      * @param ms  The number of milliseconds to wait before collapsing.
      */
     public void collapseAfter(int ms) {
-        Log.i(TAG, "initialLogsComplete()");
+        Log.i(TAG, "collapseAfter "+ms+" ms");
         Timer myTimer = new Timer();
         myTimer.schedule(new TimerTask() {
             @Override


### PR DESCRIPTION
- Reduce the number of points used to draw the driving route. Processing too many points during animation was bogging down older phones. Added new "Reduction" preference to allow fine tuning.
- Fix crash when turning off route mode during playback.
- When new cloudlet is introduced via FindCloudletEvent, draw it in green to show it is closest.
- When cloudlet is removed, mark it as such, so we can change the info window shippet to "Has been removed".
- Hide "Verify Location" menu item as we don't currently want to expose that API call.
- Enable desugaring to support java.time.LocalDateTime from Java 8 on API < 26.