### PR TITLE
EDGECLOUD-5414 Removing verifyLocation, using working default settings

### DIFF
--- a/android/MobiledgeXSDKDemo/CHANGELOG.md
+++ b/android/MobiledgeXSDKDemo/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the **Android SDK Demo App** project will be documented in this file.
 
+## 2021 releases
+
+### 1.1.17 - Sep 3, 2:40 PM
+
+#### Major Features:  
+- EDGECLOUD-4940 Add support for routes, and using the locations to demonstrate EdgeEvents
+- EDGECLOUD-5017 Add preferences for EdgeEvents config
+
+#### Improvements and Bug Fixes
+- EDGECLOUD-2553 Remove base64 encoding of image data
+- EDGECLOUD-5092 Add TLS switch preference for the case of overriding the Edge hostname
+- EDGECLOUD-4594 Add option for using SDK's NetTest for cloudlet latency testing.
+- EDGECLOUD-3589 HA features with CV activities don't handle non-success cases for FindCloudlet
+- EDGECLOUD-4940 Settings update
+  - Migrated Settings screens to androidx.
+  - Broke Computer Vision Settings into 3 separate pages.
+  - Added preferences for driving/flying route animation duration.
+- New context/popup menu for the event log viewer: Long press the collapse/expand button to select one of these menu items:
+  - Copy all items
+  - Clear Logs
+  - Auto Expand toggle - Turn off, and viewer doesn't automatically expand when new event occurs.
+- Added CSS to "About" HTML to the use MobiledgeX colors instead of stark black and white.
+
 ## 2020 releases
 
 ### 1.1.12 - Oct 2, 10:40 AM

--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 63
-        versionName "1.1.17"
+        versionName "1.1.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/res/xml/pref_speed_test.xml
@@ -35,7 +35,7 @@
         app:iconSpaceReserved="false"/>
 
     <ListPreference
-        android:defaultValue="ping"
+        android:defaultValue="socket"
         android:entries="@array/pref_latency_test_method_titles"
         android:entryValues="@array/pref_latency_test_method_values"
         android:key="@string/pref_latency_method"

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ObjectProcessorFragment.java
@@ -148,15 +148,6 @@ public class ObjectProcessorFragment extends GpuImageProcessorFragment implement
                 .build();
 
         setAppNameForGpu();
-
-        if (mEdgeHostNameOverride) {
-            mEdgeHostList.clear();
-            mEdgeHostListIndex = 0;
-            mEdgeHostList.add(mHostDetectionEdge);
-            showMessage("Overriding Edge host. Host=" + mHostDetectionEdge);
-            restartImageSenderEdge();
-        } else {
-            meHelper.findCloudletInBackground();
-        }
+        getProvisioningData();
     }
 }

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/PoseProcessorFragment.java
@@ -156,15 +156,6 @@ public class PoseProcessorFragment extends GpuImageProcessorFragment implements 
                 .build();
 
         setAppNameForGpu();
-
-        if (mEdgeHostNameOverride) {
-            mEdgeHostList.clear();
-            mEdgeHostListIndex = 0;
-            mEdgeHostList.add(mHostDetectionEdge);
-            showMessage("Overriding Edge host. Host=" + mHostDetectionEdge);
-            restartImageSenderEdge();
-        } else {
-            meHelper.findCloudletInBackground();
-        }
+        getProvisioningData();
     }
 }

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
@@ -70,7 +70,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -85,12 +84,14 @@ import static distributed_match_engine.AppClient.ServerEdgeEvent.ServerEventType
 
 public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "MatchingEngineHelper";
+    public static final boolean VERIFY_LOCATION_ENABLED = false;
     public static boolean mEdgeEventsConfigUpdated = false;
+    public static boolean mAppDefinitionUpdated = false;
     private Activity mActivity;
     private final View mView;
     private EdgeEventsSubscriber mEdgeEventsSubscriber;
     public int mDmePort = 50051;
-    public static final String DEFAULT_DME_HOSTNAME = "wifi.dme.mobiledgex.net";
+    public static final String DEFAULT_DME_HOSTNAME = "eu-mexdemo.dme.mobiledgex.net"; //TODO: Change back to wifi whenever that gets fixed.
     public static final String DEFAULT_CARRIER_NAME = "";
     public static final String DEF_HOSTNAME_PLACEHOLDER = "Default";
     public static final String DEFAULT_FIND_CLOUDLET_MODE = "PROXIMITY";
@@ -109,7 +110,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
 
     public Location mLastKnownLocation;
     public Location mLocationInSimulator;
-    private String mSessionCookie;
+    public String mSessionCookie;
     public AppClient.FindCloudletReply mClosestCloudlet;
     public AppClient.AppInstListReply mAppInstanceReplyList;
     public boolean mAllowLocationSimulatorUpdate = false;
@@ -350,9 +351,11 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
                     Log.e(TAG, "getAppInstList failed. aborting doEnhancedLocationUpdateInBackground");
                     return;
                 }
-                if (!verifyLocation()) {
-                    Log.e(TAG, "verifyLocation failed. aborting doEnhancedLocationUpdateInBackground");
-                    return;
+                if (VERIFY_LOCATION_ENABLED) {
+                    if (!verifyLocation()) {
+                        Log.e(TAG, "verifyLocation failed. aborting doEnhancedLocationUpdateInBackground");
+                        return;
+                    }
                 }
                 if (!findCloudlet()) {
                     Log.e(TAG, "findCloudlet failed. aborting doEnhancedLocationUpdateInBackground");
@@ -781,15 +784,12 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
             Log.e(TAG, "mActivity is null, possibly after onDestroy()");
             return;
         }
-        boolean appInfoChanged = false;
 
         if (key.equals(prefKeyAllowMatchingEngineLocation)) {
             boolean matchingEngineLocationAllowed = prefs.getBoolean(prefKeyAllowMatchingEngineLocation, false);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+matchingEngineLocationAllowed);
             MatchingEngine.setMatchingEngineLocationAllowed(matchingEngineLocationAllowed);
-            if (matchingEngineLocationAllowed) {
-                meHelperInterface.getCloudlets(true);
-            }
+            mAppDefinitionUpdated = true;
         }
 
         if (key.equals(prefKeyAllowNetSwitch)) {
@@ -820,7 +820,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         }
 
         if (key.equals(prefKeyDefaultDmeHostname)) {
-            boolean useDefault = prefs.getBoolean(prefKeyDefaultDmeHostname, true);
+            boolean useDefault = prefs.getBoolean(prefKeyDefaultDmeHostname, false);
             if (useDefault) {
                 new Thread(() -> {
                     try {
@@ -842,7 +842,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         }
 
         if (key.equals(prefKeyDefaultOperatorName)) {
-            boolean useDefault = prefs.getBoolean(prefKeyDefaultOperatorName, true);
+            boolean useDefault = prefs.getBoolean(prefKeyDefaultOperatorName, false);
             if (useDefault) {
                 // This will try to get the MccMnc from the device, unless wifiOnly is set.
                 mDefaultCarrierName = me.getCarrierName(mActivity);
@@ -894,7 +894,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
                 mAppInstancesLimit = DEFAULT_APP_INSTANCES_LIMIT;
             }
             Log.i(TAG, "appInstancesLimit="+appInstancesLimit+" mAppInstancesLimit="+mAppInstancesLimit);
-            appInfoChanged = true;
+            mAppDefinitionUpdated = true;
         }
 
         if (key.equals(prefKeyDefaultAppInfo)) {
@@ -909,33 +909,27 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
                 mOrgName = prefs.getString(prefKeyOrgName, mActivity.getResources().getString(R.string.org_name));
                 Log.i(TAG, "onSharedPreferenceChanged("+key+")=false. Custom values: appName="+mAppName+" appVersion="+mAppVersion+" orgName="+mOrgName);
             }
-            appInfoChanged = true;
+            mAppDefinitionUpdated = true;
         }
 
         if (key.equals(prefKeyAppName)) {
             mAppName = prefs.getString(key, mActivity.getResources().getString(R.string.dme_app_name));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mAppName);
-            appInfoChanged = true;
+            mAppDefinitionUpdated = true;
         }
         if (key.equals(prefKeyAppVersion)) {
             mAppVersion = prefs.getString(key, mActivity.getResources().getString(R.string.app_version));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mAppVersion);
-            appInfoChanged = true;
+            mAppDefinitionUpdated = true;
         }
         if (key.equals(prefKeyOrgName)) {
             mOrgName = prefs.getString(key, mActivity.getResources().getString(R.string.org_name));
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mOrgName);
-            appInfoChanged = true;
+            mAppDefinitionUpdated = true;
         }
 
         // Separated the Edge Event Settings into their own method.
         onEdgeEventPreferenceChanged(prefs, key);
-
-        if (appInfoChanged) {
-            mSessionCookie = null;
-            mClosestCloudlet = null;
-            meHelperInterface.getCloudlets(true);
-        }
     }
 
     /**
@@ -949,7 +943,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
 
         if (key.equals(prefKeyEnableEdgeEvents)) {
             mEdgeEventsConfigUpdated = true;
-            boolean value = prefs.getBoolean(key, false);
+            boolean value = prefs.getBoolean(key, true);
             mEdgeEventsEnabled = value;
             String message;
             if (mEdgeEventsEnabled) {
@@ -1022,7 +1016,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
             mEdgeEventsConfigUpdated = true;
         }
         if (key.equals(prefKeyLatencyTestType)) {
-            String value = prefs.getString(key, "PING");
+            String value = prefs.getString(key, "CONNECT");
             mEdgeEventsConfig.latencyTestType = NetTest.TestType.valueOf(value);
         }
         if (key.equals(prefKeyLatencyTestTriggerMode)) {
@@ -1048,18 +1042,23 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
     }
 
     public void setCarrierName(String carrierName) {
+        Log.i(TAG, "setCarrierName("+carrierName+")");
         mSessionCookie = null;
         mCarrierName = carrierName;
         mClosestCloudlet = null;
-        meHelperInterface.getCloudlets(true);
+        mAppDefinitionUpdated = true;
     }
 
     public void setDmeHostname(String hostname) {
+        Log.i(TAG, "setDmeHostname("+hostname+")");
+        meHelperInterface.showMessage("Using DME: "+hostname);
         mSessionCookie = null;
         mDmeHostname = hostname;
         mClosestCloudlet = null;
-        checkForLocSimulator(mDmeHostname);
-        meHelperInterface.getCloudlets(true);
+        if (VERIFY_LOCATION_ENABLED) {
+            checkForLocSimulator(mDmeHostname);
+        }
+        mAppDefinitionUpdated = true;
     }
 
     public static String parseDmeHost(String hostAndPort) throws HostParseException {

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_general.xml
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_general.xml
@@ -6,7 +6,7 @@
     android:id="@+id/general_preference_screen">
 
     <CheckBoxPreference
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:disableDependentsState="true"
         android:key="@string/pref_default_dme_hostname"
         android:summary="@string/pref_summary_default_dme_hostname"
@@ -26,7 +26,7 @@
         app:iconSpaceReserved="false"/>
 
     <CheckBoxPreference
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:disableDependentsState="true"
         android:key="@string/pref_default_operator_name"
         android:summary="@string/pref_summary_default_operator_name"

--- a/android/WorkshopCompleted/.idea/misc.xml
+++ b/android/WorkshopCompleted/.idea/misc.xml
@@ -11,6 +11,7 @@
         <entry key="app/src/main/res/drawable/ic_menu_camera.xml" value="0.2015625" />
         <entry key="app/src/main/res/drawable/ic_menu_help.xml" value="0.2015625" />
         <entry key="app/src/main/res/layout/app_bar_main.xml" value="0.18541666666666667" />
+        <entry key="app/src/main/res/layout/content_main.xml" value="0.3101851851851852" />
         <entry key="app/src/main/res/layout/fragment_face_processor.xml" value="0.25" />
         <entry key="app/src/main/res/menu/activity_main_drawer.xml" value="0.18541666666666667" />
       </map>

--- a/android/WorkshopCompleted/app/build.gradle
+++ b/android/WorkshopCompleted/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.ads:ads-identifier:1.0.0-alpha04'
 
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:3.0-rc2-rebuild'
+    implementation 'com.mobiledgex:matchingengine:3.0'
     implementation 'com.mobiledgex:mel:1.0.11'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
@@ -54,6 +54,6 @@ dependencies {
     // MobiledgeX Computer Vision library
     implementation 'com.mobiledgex:computervision:1.1.6'
     // MobiledgeX matchingenginehelper, for EventLogViewer
-    implementation "com.mobiledgex:matchingenginehelper:3.0-rc2-rebuild"
+    implementation "com.mobiledgex:matchingenginehelper:3.0"
 
 }

--- a/android/WorkshopCompleted/app/src/main/res/layout/content_main.xml
+++ b/android/WorkshopCompleted/app/src/main/res/layout/content_main.xml
@@ -61,26 +61,6 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <CheckBox
-                android:id="@+id/checkBoxLocationVerified"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:clickable="false"
-                android:text="@string/location_verified_question"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        </TableRow>
-
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="5dip">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
                 android:text="App Name:"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 

--- a/android/WorkshopCompleted/build.gradle
+++ b/android/WorkshopCompleted/build.gradle
@@ -41,7 +41,7 @@ allprojects {
                 username artifactory_user
                 password artifactory_password
             }
-            url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
+            url "https://artifactory.mobiledgex.net/artifactory/maven-releases/"
         }
     }
 }


### PR DESCRIPTION
- Remove verifyLocation completely from Workshop app.
- Hide "Verify Location" menu item, and skip verifyLocation when pressing the lower-right "Do all steps" button. This can easily be added back by changing the VERIFY_LOCATION_ENABLED constant value.
- Updated CHANGLOG.
- Fixed pause not working during route mode.
- Instead of performing getAppInstList() every time any applicable setting is changed, now we only do it when resuming the MainActivity after exiting the SettingsActivity. Any applicable setting updates the static variable mAppDefinitionUpdated and that is checked in onResume().
- Pose and Object detection were not correctly handling hostname override settings. Fixed.
- Fixed TLS selection when starting CV activities. Now works properly for TLS and non-TLS.
- Fixed bug where triggers weren't being included in custom EdgeEventsConfig.