### PR TITLE
EDGECLOUD-5603 EDGECLOUD-5592

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 63
-        versionName "1.1.18"
+        versionCode 64
+        versionName "1.1.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -621,7 +621,7 @@ public class MainActivity extends AppCompatActivity
             meHelper.registerClientInBackground();
         }
         if (id == R.id.action_get_app_inst_list) {
-            getCloudlets(true);
+            getCloudlets(true, false);
         }
         if (id == R.id.action_reset_location) {
             // Reset spoofed GPS
@@ -644,7 +644,7 @@ public class MainActivity extends AppCompatActivity
             if(meHelper.mAllowLocationSimulatorUpdate) {
                 updateLocSimLocation(lastKnownLocation.getLatitude(), lastKnownLocation.getLongitude());
             }
-            getCloudlets(true);
+            getCloudlets(true, false);
             return true;
         }
         if (id == R.id.action_verify_location) {
@@ -1005,9 +1005,11 @@ public class MainActivity extends AppCompatActivity
     /**
      * Gets list of cloudlets from DME, and populates map with markers.
      * @param clearExisting
+     * @param background
      */
-    public void getCloudlets(boolean clearExisting) {
+    public void getCloudlets(boolean clearExisting, boolean background) {
         Log.i(TAG, "getCloudlets()  meHelper="+ meHelper);
+        mAppDefinitionUpdated = false;
         if (meHelper == null) {
             Log.i(TAG, "getCloudlets() meHelper not yet initialized");
             return;
@@ -1034,7 +1036,11 @@ public class MainActivity extends AppCompatActivity
 
         showMessage("Performing getAppInstList");
         try {
-            meHelper.getAppInstList();
+            if (background) {
+                meHelper.getAppInstListInBackground();
+            } else {
+                meHelper.getAppInstList();
+            }
         } catch (InterruptedException | ExecutionException e) {
             String message = "Error during getAppInstList: " + e;
             Log.e(TAG, message);
@@ -1349,7 +1355,7 @@ public class MainActivity extends AppCompatActivity
     public void onFindCloudlet(final AppClient.FindCloudletReply closestCloudlet) {
         Log.i(TAG, "onFindCloudlet "+closestCloudlet.getFqdn());
         // Get full list of cloudlets again in case any have been added or removed.
-        getCloudlets(false);
+        getCloudlets(false, false);
         initAllCloudletMarkers();
         Cloudlet cloudlet = null;
         meHelper.mClosestCloudlet = null;
@@ -1821,7 +1827,7 @@ public class MainActivity extends AppCompatActivity
                     .build();
         }
 
-        Log.i(TAG, "onResume() mEdgeEventsConfigUpdated="+mEdgeEventsConfigUpdated);
+        Log.i(TAG, "onResume() mEdgeEventsConfigUpdated="+mEdgeEventsConfigUpdated+" mAppDefinitionUpdated="+mAppDefinitionUpdated);
         if (mEdgeEventsEnabled && mEdgeEventsConfigUpdated) {
             meHelper.startEdgeEvents();
         }
@@ -1829,7 +1835,7 @@ public class MainActivity extends AppCompatActivity
         if (mAppDefinitionUpdated) {
             meHelper.mSessionCookie = null;
             meHelper.mClosestCloudlet = null;
-            getCloudlets(true);
+            getCloudlets(true, true);
         }
 
         startLocationUpdates();

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/qoe/QoeMapActivity.java
@@ -1123,7 +1123,7 @@ public class QoeMapActivity extends AppCompatActivity implements OnMapReadyCallb
     }
 
     @Override
-    public void getCloudlets(boolean clearExisting) {
+    public void getCloudlets(boolean clearExisting, boolean background) {
         Log.i(TAG, "getCloudlets called. Nothing to do for this implementation");
     }
 

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0"
+project.ext.matchingengineVersion = "3.0.1"
 project.ext.melVersion = "1.0.11"
 project.ext.grpcVersion = '1.32.1'
 

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -285,7 +285,7 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
     }
 
     @Override
-    public void getCloudlets(boolean clearExisting) {
+    public void getCloudlets(boolean clearExisting, boolean background) {
         // Not used for this non-map activity.
     }
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
@@ -286,6 +286,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
     }
 
     public void startEdgeEvents() {
+        mEdgeEventsConfigUpdated = false;
         if (!mEdgeEventsEnabled) {
             Log.e(TAG, "Aborting attempt to startEdgeEvents while mEdgeEventsEnabled="+ false);
             return;
@@ -1287,7 +1288,6 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
 
         // Only the app knows with any certainty which AppPort (and internal port array)
         // it wants to test, so this is in the application.
-        @Subscribe
         void handleLatencyRequest(AppClient.ServerEdgeEvent event) {
             if (event.getEventType() != AppClient.ServerEdgeEvent.ServerEventType.EVENT_LATENCY_REQUEST) {
                 return;
@@ -1387,7 +1387,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
                 }
 
                 if(!mGpsInitialized) {
-                    meHelperInterface.getCloudlets(true);
+                    meHelperInterface.getCloudlets(true, false);
                     mGpsInitialized = true;
                 }
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelperInterface.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelperInterface.java
@@ -26,6 +26,6 @@ public interface MatchingEngineHelperInterface {
     void onGetCloudletList(AppClient.AppInstListReply cloudletList);
     void showMessage(String text);
     void showError(String text);
-    void getCloudlets(boolean clearExisting);
+    void getCloudlets(boolean clearExisting, boolean background);
     ConnectionTester makeConnectionTester(boolean tls);
 }


### PR DESCRIPTION
- Remove subscription to handleLatencyRequest. Let the SDK handle it.
- Better tracking of the flags mEdgeEventsConfigUpdated and mAppDefinitionUpdated, to be checked in onResume.
- Add "background" parameter to getCloudlets, so if onResume needs to call it, it will be in the background and not pause the UI when you close the Settings page.