### PR TITLE
Move errors to Event Log Viewer, remove duplicates

### DIFF
--- a/android/WorkshopCompleted/app/build.gradle
+++ b/android/WorkshopCompleted/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.ads:ads-identifier:1.0.0-alpha04'
 
     // Matching Engine SDK
-    implementation 'com.mobiledgex:matchingengine:3.0'
+    implementation 'com.mobiledgex:matchingengine:3.0.1'
     implementation 'com.mobiledgex:mel:1.0.11'
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
@@ -54,6 +54,6 @@ dependencies {
     // MobiledgeX Computer Vision library
     implementation 'com.mobiledgex:computervision:1.1.6'
     // MobiledgeX matchingenginehelper, for EventLogViewer
-    implementation "com.mobiledgex:matchingenginehelper:3.0"
+    implementation "com.mobiledgex:matchingenginehelper:3.0.1"
 
 }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/FaceProcessorFragment.java
@@ -286,4 +286,9 @@ public class FaceProcessorFragment extends com.mobiledgex.computervision.ImagePr
     public String getStatsText() {
         return mImageSenderEdge.getStatsText();
     }
+
+    @Override
+    public void getCloudlets(boolean clearExisting, boolean background) {
+        // Required for MatchingEngineHelperInterface. Not used for this non-map activity.
+    }
 }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -115,7 +115,6 @@ public class MainActivity extends AppCompatActivity
 
     private String registerStatusText;
     private String findCloudletStatusText;
-    private String verifyLocStatusText;
     private String getQosPosStatusText;
     private EventLogViewer mEventLogViewer;
     private EdgeEventsSubscriber mEdgeEventsSubscriber;
@@ -274,7 +273,13 @@ public class MainActivity extends AppCompatActivity
             Log.e(TAG, "Could not generate host");
             host = "wifi.dme.mobiledgex.net";   //fallback host
         }
-//        host = "eu-mexdemo.dme.mobiledgex.net";
+
+        // The generateDmeHostAddress() call above will generate a hostname that includes the
+        // MCC+MNC of your current provider. Example: AT&T is 310-410.dme.mobiledgex.net.
+        // Since most of these values haven't been mapped to a live DME, here we override
+        // the host with a known good value for a DME that has our app instance deployed.
+        host = "eu-mexdemo.dme.mobiledgex.net";
+
         port = matchingEngine.getPort(); // Keep same port.
         AppClient.RegisterClientRequest registerClientRequest;
         registerClientRequest = matchingEngine.createDefaultRegisterClientRequest(ctx, orgName)
@@ -509,7 +514,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     public void showErrorMsg(String msg) {
-        Snackbar.make(findViewById(android.R.id.content), msg, Snackbar.LENGTH_LONG).show();
+        mEventLogViewer.showError(msg);
     }
 
     @Override
@@ -562,6 +567,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     public class RegisterClientBackgroundRequest extends AsyncTask<Object, Void, Boolean> {
+        boolean errorShown = false;
         @Override
         protected Boolean doInBackground(Object... params) {
             try {
@@ -570,6 +576,7 @@ public class MainActivity extends AppCompatActivity
                 e.printStackTrace();
                 registerStatusText = "Registration Failed. Exception="+e.getLocalizedMessage();
                 showErrorMsg(registerStatusText);
+                errorShown = true;
                 return false;
             }
         }
@@ -586,12 +593,15 @@ public class MainActivity extends AppCompatActivity
             } else {
                 registerStatusText = "Failed to register client. " + registerStatusText;
                 Log.e(TAG, registerStatusText);
-                showErrorMsg(registerStatusText);
+                if (!errorShown) {
+                    showErrorMsg(registerStatusText);
+                }
             }
         }
     }
 
     public class FindCloudletBackgroundRequest extends AsyncTask<Object, Void, Boolean> {
+        boolean errorShown = false;
         @Override
         protected Boolean doInBackground(Object... params) {
             try {
@@ -600,6 +610,7 @@ public class MainActivity extends AppCompatActivity
                 e.printStackTrace();
                 findCloudletStatusText = ". Exception="+e.getLocalizedMessage();
                 showErrorMsg(findCloudletStatusText);
+                errorShown = true;
                 return false;
             }
         }
@@ -609,7 +620,9 @@ public class MainActivity extends AppCompatActivity
             if (!cloudletFound) {
                 findCloudletStatusText = "Failed to find cloudlet. " + findCloudletStatusText;
                 Log.e(TAG, findCloudletStatusText);
-                showErrorMsg(findCloudletStatusText);
+                if (!errorShown) {
+                    showErrorMsg(findCloudletStatusText);
+                }
             }
         }
     }

--- a/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
+++ b/android/WorkshopCompleted/app/src/main/java/com/mobiledgex/workshopskeleton/MainActivity.java
@@ -628,6 +628,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     public class QoSPosBackgroundRequest extends AsyncTask<Object, Void, Boolean> {
+        boolean errorShown = false;
         @Override
         protected Boolean doInBackground(Object... params) {
             Location location = (Location) params[0];
@@ -642,11 +643,11 @@ public class MainActivity extends AppCompatActivity
                 } else {
                     return false;
                 }
-            } catch (InterruptedException ie) {
-                ie.printStackTrace();
-            } catch (ExecutionException ee) {
-                getQosPosStatusText = ee.getMessage();
+            } catch (InterruptedException | ExecutionException e ) {
+                e.printStackTrace();
+                getQosPosStatusText = e.getMessage();
                 Log.e(TAG, getQosPosStatusText);
+                errorShown = true;
             }
             return false;
         }
@@ -656,7 +657,9 @@ public class MainActivity extends AppCompatActivity
             if (!gotQoSPositions) {
                 getQosPosStatusText = "Failed to get qosPositions. " + getQosPosStatusText;
                 Log.e(TAG, getQosPosStatusText);
-                showErrorMsg(getQosPosStatusText);
+                if (!errorShown) {
+                    showErrorMsg(getQosPosStatusText);
+                }
             }
         }
     }

--- a/android/WorkshopCompleted/build.gradle
+++ b/android/WorkshopCompleted/build.gradle
@@ -41,7 +41,7 @@ allprojects {
                 username artifactory_user
                 password artifactory_password
             }
-            url "https://artifactory.mobiledgex.net/artifactory/maven-releases/"
+            url "https://artifactory.mobiledgex.net/artifactory/maven-development/"
         }
     }
 }


### PR DESCRIPTION
- Instead of a Snackbar, display errors in the Event Log Viewer.
- Remove duplicate error messages.
- Overriding the value of generateDmeHostAddress() with always-working EU DME. Code comment about why this is done.