### PR TITLE
EDGECLOUD-5672 EDGECLOUD-5677 Vid name and app inst limit update

### DIFF
--- a/android/MobiledgeXSDKDemo/CHANGELOG.md
+++ b/android/MobiledgeXSDKDemo/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the **Android SDK Demo App** project will be documented i
 
 ## 2021 releases
 
-### 1.1.20 - Sep 23, 4:40 PM
+### 1.1.21 - Oct 5, 0:00 PM
+- EDGECLOUD-5672 Object Detection's Play Video function now uses the correct "objects" video file name.
+- EDGECLOUD-5677 "Get App Instances Limit" Setting is now a numeric-only text field to allow for larger values.
+
+### 1.1.20 - Sep 23, 4:12 PM
 - EDGECLOUD-5592 SampleApp MobiledgeX SDK Demo slow after LatencyRequest from server is sent
 - EDGECLOUD-5414 Removed "Verify Location" menu item and button action.
 - EDGECLOUD-5603 Demo app - After displaying "Cloudlet Details" page, closest cloudlet is cleared  

--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 65
-        versionName "1.1.20"
+        versionCode 66
+        versionName "1.1.21"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [GOOGLE_MAPS_API_KEY: "${googleMapsApiKey}"]

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -321,7 +321,6 @@ public class MainActivity extends AppCompatActivity
         upgradeToVersion59(prefs);
 
         // Reuse the onSharedPreferenceChanged code to initialize anything dependent on these prefs:
-        onSharedPreferenceChanged(prefs, getResources().getString(R.string.pref_app_instances_limit));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.download_size));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.upload_size));
         onSharedPreferenceChanged(prefs, getResources().getString(R.string.latency_packets));

--- a/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
+++ b/android/MobiledgeXSDKDemo/computervision/src/main/java/com/mobiledgex/computervision/ImageProcessorFragment.java
@@ -1257,8 +1257,6 @@ public class ImageProcessorFragment extends Fragment implements MatchingEngineHe
                 .setPersistentTcpPort(PERSISTENT_TCP_PORT)
                 .build();
 
-        mVideoFilename = VIDEO_FILE_NAME;
-
         //One more call to get preferences for ImageSenders
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         onSharedPreferenceChanged(prefs, ALL_PREFS);

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
@@ -52,6 +52,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEFAULT_APP_INSTANCES_LIMIT;
 import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEFAULT_CARRIER_NAME;
 import static com.mobiledgex.matchingenginehelper.MatchingEngineHelper.DEFAULT_DME_HOSTNAME;
 
@@ -145,9 +146,24 @@ public class SettingsActivity extends AppCompatActivity implements
     }
 
     public static class MatchingEngineSettingsFragment extends PreferenceFragmentCompat {
+        private String prefKeyAppInstancesLimit;
+        private EditTextPreference prefAppInstancesLimit;
+
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.pref_matching_engine, rootKey);
+        }
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+            prefKeyAppInstancesLimit = getResources().getString(R.string.pref_app_instances_limit);
+            prefAppInstancesLimit = findPreference(prefKeyAppInstancesLimit);
+            prefAppInstancesLimit.setSummaryProvider(preference -> getResources().getString(R.string.pref_app_instances_limit_summary, prefAppInstancesLimit.getText()));
+            prefAppInstancesLimit.setOnBindEditTextListener(editText -> {
+                SetEditTextNumerical(editText);
+            });
         }
     }
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/values/strings.xml
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/values/strings.xml
@@ -69,27 +69,7 @@
 
     <string name="pref_app_instances_limit">app_instances_limit</string>
     <string name="pref_app_instances_limit_title">Get App Instances Limit</string>
-    <string name="pref_app_instances_limit_summary">%s</string>
-    <string-array name="pref_app_instances_limit_titles">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-        <item>6</item>
-        <item>7</item>
-        <item>8</item>
-    </string-array>
-    <string-array name="pref_app_instances_limit_values">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-        <item>6</item>
-        <item>7</item>
-        <item>8</item>
-    </string-array>
+    <string name="pref_app_instances_limit_summary">The max number of cloudlets to display: %s</string>
 
     <string name="pref_google_map_type">pref_google_map_type</string>
     <string name="title_activity_settings">SettingsActivity</string>

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_matching_engine.xml
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/res/xml/pref_matching_engine.xml
@@ -37,11 +37,12 @@
         android:summary="@string/pref_find_cloudlet_mode_summary"
         android:title="@string/pref_find_cloudlet_mode_title"
         app:iconSpaceReserved="false" />
-    <ListPreference
+
+    <EditTextPreference
         android:defaultValue="4"
-        android:entries="@array/pref_app_instances_limit_titles"
-        android:entryValues="@array/pref_app_instances_limit_values"
         android:key="@string/pref_app_instances_limit"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
         android:summary="@string/pref_app_instances_limit_summary"
         android:title="@string/pref_app_instances_limit_title"
         app:iconSpaceReserved="false" />


### PR DESCRIPTION
- Use correct video file name for Object Detection activity. (Was being incorrectly overridden in parent class's startImageSenders() method.)
- To allow for higher values, change "Get App Inst Limit" Setting to use a numeric-only text input field.
- Added a SummaryProvider for the setting.