### PR TITLE
EDGECLOUD-6088 Demo app - Add support for QosPrioritySession APIs

### DIFF
--- a/android/MobiledgeXSDKDemo/app/build.gradle
+++ b/android/MobiledgeXSDKDemo/app/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation "com.mobiledgex:matchingengine:${matchingengineVersion}"
-    implementation "com.mobiledgex:mel:${melVersion}"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
@@ -1,5 +1,6 @@
 package com.mobiledgex.sdkdemo;
 
+import android.content.pm.PackageManager;
 import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -28,6 +29,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import distributed_match_engine.AppClient;
 
 /**
  * QoS for stable latency/throughput API. See:
@@ -36,7 +40,6 @@ import java.util.Map;
  */
 public class DtQosPrioritySessions {
     private static final String TAG = "DtQosPrioritySessions";
-    public static final String QOS_API_URL = "https://staging-api.developer.telekom.com";
     private static MainActivity mActivity;
     private static MatchingEngineHelper meHelper;
 
@@ -46,10 +49,11 @@ public class DtQosPrioritySessions {
         Log.i(TAG, "meHelper.mQosSessionId="+meHelper.mQosSessionId+" meHelper.mQosProfileName="+meHelper.mQosProfileName);
         // Create dialog with QOS profile names.
         List<String> items = new ArrayList<>();
-        items.add("LOW_LATENCY");
-        items.add("THROUGHPUT_S");
-        items.add("THROUGHPUT_M");
-        items.add("THROUGHPUT_L");
+        for (AppClient.QosSessionProfile profileName : AppClient.QosSessionProfile.values()) {
+            if (!profileName.name().endsWith("NO_PRIORITY") && !profileName.name().equals("UNRECOGNIZED")) {
+                items.add(profileName.name());
+            }
+        }
         Log.i(TAG, "items="+items);
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
         builder.setTitle("Update Session Priority");
@@ -77,17 +81,14 @@ public class DtQosPrioritySessions {
 
         Button buttonDelSession = content.findViewById(R.id.button_delete);
         buttonDelSession.setOnClickListener(view -> {
-            String url = buildQosUrl(meHelper.mQosProfileName);
-            url += "/"+meHelper.mQosSessionId;
-            sendHttpRequest(Request.Method.DELETE, url, "", -1, "", "");
+            meHelper.qosPrioritySessionDeleteInBackground();
             alertDialog.cancel();
         });
 
         Button buttonSesDetails = content.findViewById(R.id.button_details);
         buttonSesDetails.setOnClickListener(view -> {
-            String url = buildQosUrl(meHelper.mQosProfileName);
-            url += "/"+meHelper.mQosSessionId;
-            sendHttpRequest(Request.Method.GET, url, "", -1, "", "");
+            String msg = meHelper.getQosPrioritySessionDetails();
+            mActivity.showMessage(msg);
             alertDialog.cancel();
         });
 
@@ -104,129 +105,9 @@ public class DtQosPrioritySessions {
         lvItems.setOnItemClickListener((parent, view, which, id1) -> {
             String selectedItemText = items.get(which);
             String requestBody = "";
-            String url = buildQosUrl(selectedItemText);
             int duration = Integer.parseInt(textDuration.getText().toString());
-            JSONObject jsonBody = new JSONObject();
-            try {
-                jsonBody.put("duration", duration);
-                jsonBody.put("asAddr", meHelper.mAppInstIp);
-                jsonBody.put("ueAddr", meHelper.mDeviceIpv4);
-                jsonBody.put("asAddr", meHelper.mAppInstIp);
-                jsonBody.put("asPorts", "8008");
-                jsonBody.put("protocolIn", "TCP");
-                jsonBody.put("protocolOut", "TCP");
-                jsonBody.put("qos", selectedItemText);
-                requestBody = jsonBody.toString();
-            } catch (JSONException e) {
-                e.printStackTrace();
-                return;
-            }
-
-            if (meHelper.mQosSessionId != null && !meHelper.mQosSessionId.isEmpty()) {
-                // Delete the old, and include parms for a second request to be called afterwards to create the new.
-                String deleteUrl = buildQosUrl(meHelper.mQosProfileName)+"/"+meHelper.mQosSessionId;
-                Log.i(TAG, "Deleting old session via "+deleteUrl);
-                sendHttpRequest(Request.Method.DELETE, deleteUrl, "", Request.Method.POST, url, requestBody);
-            } else {
-                // Create a new one from scratch
-                sendHttpRequest(Request.Method.POST, url, requestBody, -1, "", "");
-            }
+            meHelper.qosPrioritySessionCreateInBackground(selectedItemText, duration);
             alertDialog.dismiss();
         });
-    }
-
-    private static String buildQosUrl(String profileName) {
-        String qosType;
-        if (profileName.indexOf("LATENCY") >= 0) {
-            qosType = "latency";
-        } else {
-            qosType = "throughput";
-        }
-        return QOS_API_URL + "/5g-" +qosType+"/sessions";
-    }
-
-    protected static void sendHttpRequest(int method, String url, String body, int method2, String url2, String body2) {
-        Log.i(TAG, "sendHttpRequest method="+method+" url="+url+" body="+body+" method2="+method2+" url2="+url2+" body2="+body2);
-        final int[] statusCode = {0};
-        final String[] methodNames = {"GET", "POST", "PUT", "DELETE"};
-        String msg = "sendHttpRequest method="+methodNames[method]+" url="+url+" body="+body;
-        Log.i(TAG, msg);
-        mActivity.showMessage(msg);
-        RequestQueue queue = Volley.newRequestQueue(mActivity.getApplicationContext());
-        // Request a string response from the provided URL.
-        StringRequest stringRequest = new StringRequest(method, url,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        if (method == Request.Method.DELETE) {
-                            meHelper.mQosSessionId = "";
-                            meHelper.mQosProfileName = "";
-                            String msg = methodNames[method]+" QOS API session response="+statusCode[0];
-                            if (!response.isEmpty()) {
-                                msg += ": "+response;
-                            }
-                            Log.i(TAG, msg);
-                            mActivity.showMessage(msg);
-                            if (method2 >= 0) {
-                                // Recursive call with the second set of parameters.
-                                sendHttpRequest(method2, url2, body2, -1, "", "");
-                            }
-                            return; // DELETE call will have no body.
-                        }
-                        // POST or GET should have a JSON response.
-                        try {
-                            JSONObject jsonObject = new JSONObject(response);
-                            String msg = methodNames[method]+" QOS API session response="+statusCode[0]+":\n"+jsonObject.toString(2);
-                            Log.i(TAG, msg);
-                            mActivity.showMessage(msg);
-                            meHelper.mQosSessionId = jsonObject.getString("id");
-                            meHelper.mQosProfileName = jsonObject.getString("qos");
-                            Log.i(TAG, "meHelper.mQosSessionId="+meHelper.mQosSessionId+" meHelper.mQosProfileName="+meHelper.mQosProfileName);
-                        } catch (JSONException e) {
-                            e.printStackTrace();
-                            String msg = methodNames[method]+" QOS API session response="+statusCode[0]+": "+response;
-                            Log.i(TAG, msg);
-                            mActivity.showMessage(msg);
-                        }
-                    }
-                }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                Log.e(TAG, "That didn't work! error="+error);
-                String msg = methodNames[method] + " API call Error: " + error.networkResponse.statusCode + " - " + new String(error.networkResponse.data, StandardCharsets.UTF_8) + " - " + error.getMessage();
-                Log.e(TAG, msg);
-                mActivity.showError(msg);
-            }
-        }) {
-            @Override
-            public String getBodyContentType() {
-                return "application/json";
-            }
-            @Override
-            public byte[] getBody() {
-                try {
-                    return body == "" ? null : body.getBytes("utf-8");
-                } catch (UnsupportedEncodingException uee) {
-                    Log.wtf(TAG, "Unsupported Encoding while trying to get the body bytes");
-                    return null;
-                }
-            }
-            @Override
-            public Map<String, String> getHeaders() {
-                // API key is stored in local.properties as dt_qos_sessions_api_key.
-                Map<String, String>  params = new HashMap<String, String>();
-                params.put("Authorization", BuildConfig.DT_QOS_SESSIONS_API_KEY);
-                params.put("accept", "application/json");
-                return params;
-            }
-            @Override
-            protected Response<String> parseNetworkResponse(NetworkResponse response) {
-                statusCode[0] = response.statusCode;
-                return super.parseNetworkResponse(response);
-            }
-        };
-
-        // Add the request to the RequestQueue.
-        queue.add(stringRequest);
     }
 }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
@@ -1,6 +1,8 @@
 package com.mobiledgex.sdkdemo;
 
-import android.content.pm.PackageManager;
+import static distributed_match_engine.AppClient.QosSessionProfile.QOS_NO_PRIORITY;
+import static distributed_match_engine.AppClient.QosSessionProfile.UNRECOGNIZED;
+
 import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -11,25 +13,10 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 
-import com.android.volley.NetworkResponse;
-import com.android.volley.Request;
-import com.android.volley.RequestQueue;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
-import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
 import com.mobiledgex.matchingenginehelper.MatchingEngineHelper;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import distributed_match_engine.AppClient;
 
@@ -50,7 +37,7 @@ public class DtQosPrioritySessions {
         // Create dialog with QOS profile names.
         List<String> items = new ArrayList<>();
         for (AppClient.QosSessionProfile profileName : AppClient.QosSessionProfile.values()) {
-            if (!profileName.name().endsWith("NO_PRIORITY") && !profileName.name().equals("UNRECOGNIZED")) {
+            if (!profileName.equals(QOS_NO_PRIORITY) && !profileName.name().equals(UNRECOGNIZED)) {
                 items.add(profileName.name());
             }
         }

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0.6-mel-removed"
-project.ext.melVersion = "1.0.11"
+project.ext.matchingengineVersion = "3.0.9"
 project.ext.grpcVersion = '1.32.1'
 
 project.ext.mobiledgeXContextUrl = "https://artifactory.mobiledgex.net/artifactory"

--- a/android/MobiledgeXSDKDemo/computervision/build.gradle
+++ b/android/MobiledgeXSDKDemo/computervision/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation 'com.android.volley:volley:1.2.0'
     implementation 'com.squareup.okhttp3:okhttp:4.2.1'
     implementation "com.mobiledgex:matchingengine:${matchingengineVersion}"
-    implementation "com.mobiledgex:mel:${melVersion}"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/build.gradle
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     implementation 'com.android.volley:volley:1.2.0'
     implementation "com.mobiledgex:matchingengine:${matchingengineVersion}"
-    implementation "com.mobiledgex:mel:${melVersion}"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
 }

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
@@ -533,7 +533,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
                 qosPrioritySessionCreate(qosProfile, duration);
             } catch (ExecutionException | InterruptedException
                     | PackageManager.NameNotFoundException | IllegalArgumentException e) {
-                Log.e(TAG, "Exception in registerClientInBackground() for "+
+                Log.e(TAG, "Exception in qosPrioritySessionCreateInBackground() for "+
                         mAppName+", "+mAppVersion+", "+mOrgName);
                 e.printStackTrace();
                 meHelperInterface.showError(e.getLocalizedMessage());


### PR DESCRIPTION
- Removed direct calls to DT's REST API server.
- "Update QOS Session" dialog now calls SDK's QosPrioritySession create/delete methods via MatchingEngineHelper.java.
- Removed getLocalIp methods and now call SDK's public methods.
- Removed MEL vestiges.