### PR TITLE
EDGECLOUD-6182 Fix 'Update QOS Session' silent failure

### DIFF
--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/DtQosPrioritySessions.java
@@ -37,7 +37,7 @@ public class DtQosPrioritySessions {
         // Create dialog with QOS profile names.
         List<String> items = new ArrayList<>();
         for (AppClient.QosSessionProfile profileName : AppClient.QosSessionProfile.values()) {
-            if (!profileName.equals(QOS_NO_PRIORITY) && !profileName.name().equals(UNRECOGNIZED)) {
+            if (!profileName.equals(QOS_NO_PRIORITY) && !profileName.equals(UNRECOGNIZED)) {
                 items.add(profileName.name());
             }
         }

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0.9"
+project.ext.matchingengineVersion = "3.0.10"
 project.ext.grpcVersion = '1.32.1'
 
 project.ext.mobiledgeXContextUrl = "https://artifactory.mobiledgex.net/artifactory"


### PR DESCRIPTION
- If FindCloudlet hadn't been performed, and a QOS profile is chosen from the "Update Session Priority" dialog, the session creation attempt would fail, because things like the app inst FQDN were not available, but there was no indication to the user of the failure. This update checks for all required values before session creation attempt, and shows an error appropriately.
- Also fixed a crash on "app not found" that was caused by not catching io.grpc.StatusRuntimeException everywhere it was needed.
- Fix for not keeping "UNRECOGNIZED" out of the profile name list because enum value wasn't compared correctly.
- Update SDK to 3.0.10