### PR TITLE
EDGECLOUD-6183 Remove Persistent TCP Server support

### DIFF
--- a/ComputerVisionServer/Dockerfile
+++ b/ComputerVisionServer/Dockerfile
@@ -28,8 +28,6 @@ RUN python manage.py collectstatic --noinput
 
 # port for REST
 EXPOSE 8008/tcp
-# port for persistent TCP server
-EXPOSE 8011/tcp
 
 # Fix for "click" Python library, a uvicorn dependency.
 ENV LC_ALL=C.UTF-8

--- a/ComputerVisionServer/Dockerfile_gpu
+++ b/ComputerVisionServer/Dockerfile_gpu
@@ -67,8 +67,6 @@ RUN python manage.py collectstatic --noinput
 
 # port for REST
 EXPOSE 8008/tcp
-# port for persistent TCP server
-EXPOSE 8011/tcp
 
 # Fix for "click" Python library, a uvicorn dependency.
 ENV LC_ALL=C.UTF-8

--- a/ComputerVisionServer/moedx/tracker/routing.py
+++ b/ComputerVisionServer/moedx/tracker/routing.py
@@ -3,8 +3,8 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path('ws/detector/detect', consumers.ImageConsumerFaceDetector),
-    re_path('ws/recognizer/predict', consumers.ImageConsumerFaceRecognizer),
-    re_path('ws/openpose/detect', consumers.ImageConsumerOpenposeDetector),
-    re_path('ws/object/detect', consumers.ImageConsumerObjectDetector),
+    re_path('ws/detector/detect', consumers.ImageConsumerFaceDetector.as_asgi()),
+    re_path('ws/recognizer/predict', consumers.ImageConsumerFaceRecognizer.as_asgi()),
+    re_path('ws/openpose/detect', consumers.ImageConsumerOpenposeDetector.as_asgi()),
+    re_path('ws/object/detect', consumers.ImageConsumerObjectDetector.as_asgi()),
 ]

--- a/ComputerVisionServer/moedx/tracker/views.py
+++ b/ComputerVisionServer/moedx/tracker/views.py
@@ -141,7 +141,9 @@ def get_image_from_request(request, type):
             return HttpResponseBadRequest("Missing 'image' parameter")
         image = base64.b64decode(request.POST.get("image"))
     else:
-        return HttpResponseBadRequest("Content-Type must be 'image/png', 'image/jpeg', 'multipart/form-data', or 'application/x-www-urlencoded'")
+        msg = "Content-Type must be 'image/png', 'image/jpeg', 'multipart/form-data', or 'application/x-www-urlencoded'"
+        logger.error(msg)
+        return HttpResponseBadRequest(msg)
 
     if request.headers.get("Mobiledgex-Debug", "") == "true":
         save_debug_image(image, request, type)

--- a/ComputerVisionServer/requirements.txt
+++ b/ComputerVisionServer/requirements.txt
@@ -16,8 +16,8 @@ websockets
 websocket-client
 uvloop
 httptools
-twisted==20.3.0
-channels==2.4.0
+twisted
+channels
 uvicorn
 redis
 whitenoise


### PR DESCRIPTION
- Remove server code (leaving moedx/facial_detection/tcp_server.py for reference).
- Remove test script code.
- Removing version restrictions on a couple of Python libraries. Minor routing.py code fix to support newer version of "channels".