### PR TITLE
EDGECLOUD-6238, EDGECLOUD-6255. NetTest and Route Mode  bug fixes

### DIFF
--- a/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
     <application
         android:allowBackup="false"
+        android:exported="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -34,6 +35,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
+            android:exported="true"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
+++ b/android/MobiledgeXSDKDemo/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
 
     <application
         android:allowBackup="false"
-        android:exported="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/Cloudlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2022 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,7 +98,7 @@ public class Cloudlet implements Serializable {
     private Context mContext;
     private boolean mRemoved;
 
-    public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, String fqdnPrefix, boolean tls, Marker marker, int port) {
+    public Cloudlet(String cloudletName, String appName, String carrierName, LatLng gpsLocation, double distance, String fqdn, String fqdnPrefix, boolean tls, Marker marker, int port, Context context) {
         Log.d(TAG, "Cloudlet contructor. cloudletName="+cloudletName);
         mCloudletName = cloudletName;
         mAppName = appName;
@@ -107,6 +107,7 @@ public class Cloudlet implements Serializable {
         mLongitude = gpsLocation.longitude;
         mDistance = distance;
         mMarker = marker;
+        mContext = context;
         setUri(fqdnPrefix, fqdn, tls, port);
 
         if(CloudletListHolder.getLatencyTestAutoStart()) {
@@ -257,10 +258,6 @@ public class Cloudlet implements Serializable {
             ex.printStackTrace();
             return false;
         }
-    }
-
-    public void setContext(Context context) {
-        mContext = context;
     }
 
     public void setRemoved(boolean removed) {

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletBuilder.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletBuilder.java
@@ -1,5 +1,7 @@
 package com.mobiledgex.sdkdemo;
 
+import android.content.Context;
+
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 
@@ -14,6 +16,7 @@ public class CloudletBuilder {
     private boolean tls;
     private Marker marker;
     private int port;
+    private Context context;
 
     public CloudletBuilder setCloudletName(String cloudletName) {
         this.cloudletName = cloudletName;
@@ -65,7 +68,12 @@ public class CloudletBuilder {
         return this;
     }
 
+    public CloudletBuilder setContext(Context context) {
+        this.context = context;
+        return this;
+    }
+
     public Cloudlet createCloudlet() {
-        return new Cloudlet(cloudletName, appName, carrierName, gpsLocation, distance, fqdn, fqdnPrefix, tls, marker, port);
+        return new Cloudlet(cloudletName, appName, carrierName, gpsLocation, distance, fqdn, fqdnPrefix, tls, marker, port, context);
     }
 }

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/CloudletDetailsActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2022 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,7 +75,6 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
         }
         Log.i(TAG, "cloudlet="+cloudlet+" "+cloudlet.getCloudletName());
         cloudlet.setSpeedTestResultsListener(this);
-        cloudlet.setContext(getApplicationContext());
 
         cloudletNameTv = findViewById(R.id.cloudletName);
         appNameTv = findViewById(R.id.appName);
@@ -213,6 +212,8 @@ public class CloudletDetailsActivity extends AppCompatActivity implements SpeedT
                         latencyMessageTv.setText("Ping failed");
                     } else if(latencyTestMethod == CloudletListHolder.LatencyTestMethod.socket) {
                         latencyMessageTv.setText("Socket test failed");
+                    } else if(latencyTestMethod == CloudletListHolder.LatencyTestMethod.NetTest) {
+                        latencyMessageTv.setText("NetTest connection failed");
                     }
                 }
                 latencyAvgTv.setText(formatValue(cloudlet.getLatencyAvg())+" ms");

--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -1936,13 +1936,13 @@ public class MainActivity extends AppCompatActivity
                 }
                 try {
                     DirectionsResult calculatedRoutes = null;
-                        calculatedRoutes = DirectionsApi.newRequest(context)
-                                .alternatives(false)
-                                .mode(TravelMode.DRIVING)
-                                .origin(new com.google.maps.model.LatLng(startLatLng.latitude, startLatLng.longitude))
-                                .waypoints(waypoints)
-                                .destination(new com.google.maps.model.LatLng(endLatLng.latitude, endLatLng.longitude))
-                                .await();
+                    calculatedRoutes = DirectionsApi.newRequest(context)
+                            .alternatives(false)
+                            .mode(TravelMode.DRIVING)
+                            .origin(new com.google.maps.model.LatLng(startLatLng.latitude, startLatLng.longitude))
+                            .waypoints(waypoints)
+                            .destination(new com.google.maps.model.LatLng(endLatLng.latitude, endLatLng.longitude))
+                            .await();
 
                     if (calculatedRoutes == null || calculatedRoutes.routes.length == 0) {
                         Log.w(TAG, "calculatedRoutes has no content");

--- a/android/MobiledgeXSDKDemo/build.gradle
+++ b/android/MobiledgeXSDKDemo/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-project.ext.matchingengineVersion = "3.0.10"
+project.ext.matchingengineVersion = "3.0.12"
 project.ext.grpcVersion = '1.32.1'
 
 project.ext.mobiledgeXContextUrl = "https://artifactory.mobiledgex.net/artifactory"

--- a/android/MobiledgeXSDKDemo/computervision/build.gradle
+++ b/android/MobiledgeXSDKDemo/computervision/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
 
     implementation 'com.android.volley:volley:1.2.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.2.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation "com.mobiledgex:matchingengine:${matchingengineVersion}"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2022 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -988,7 +988,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         }
 
         if (key.equals(prefKeyMatchingEngineUseSsl)) {
-            mMatchingEngineSSL = prefs.getBoolean(prefKeyMatchingEngineUseSsl, false);
+            mMatchingEngineSSL = prefs.getBoolean(prefKeyMatchingEngineUseSsl, true);
             Log.i(TAG, "onSharedPreferenceChanged("+key+")="+mMatchingEngineSSL);
             me.setSSLEnabled(mMatchingEngineSSL);
         }


### PR DESCRIPTION
- Pass in Context when initializing a Cloudlet so it can be used in the background for NetTest on auto start latency test.
- For driving route animation, make pause button actually pause the animation. (How did this never work before?)
- Fix first-run default for mMatchingEngineSSL boolean.
- Upgraded API versions based on Android Studio's recommendation. This caused some bugs:
  - routeBetweenPoints() has a mix of networking calls and UI update calls. Everything was working fine, but API 30 caused some "java.lang.IllegalStateException: Not on the main thread" and CalledFromWrongThreadExceptions to be thrown. Needed to rework the method to run in the background and update the UI via runOnUiThread().
  - Upgraded okhttp3 lib version due to NoSuchMethodException introduced in older versions by API 30.
