### PR TITLE
EDGECLOUD-6331 Carrier name fix for wifi-only

### DIFF
--- a/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/android/MobiledgeXSDKDemo/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -552,11 +552,15 @@ public class MainActivity extends AppCompatActivity
                 sb.append(str);
             }
             String htmlData = sb.toString();
+            String carrierName = meHelper.getCarrierName();
+            if (carrierName.equals("")) {
+                carrierName = "blank (wildccard)";
+            }
             htmlData = htmlData.replace("${androidAppVersion}", appVersion)
                     .replace("${appName}", meHelper.mAppName)
                     .replace("${appVersion}", meHelper.mAppVersion)
                     .replace("${orgName}", meHelper.mOrgName)
-                    .replace("${carrier}", meHelper.mCarrierName)
+                    .replace("${carrier}", carrierName)
                     .replace("${region}", meHelper.mDmeHostname)
                     .replace(".dme.mobiledgex.net", "");
             Log.i(TAG, "htmlData=\n"+htmlData);
@@ -739,7 +743,7 @@ public class MainActivity extends AppCompatActivity
             Intent intent = new Intent(this, QoeMapActivity.class);
             Log.i(TAG, "mDmeHostname="+ meHelper. mDmeHostname);
             intent.putExtra(QoeMapActivity.EXTRA_HOSTNAME, meHelper.mDmeHostname);
-            intent.putExtra(QoeMapActivity.EXTRA_CARRIER_NAME, meHelper.mCarrierName);
+            intent.putExtra(QoeMapActivity.EXTRA_CARRIER_NAME, meHelper.getCarrierName());
             startActivity(intent);
             return true;
         } else if (id == R.id.nav_google_signin) {

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/MatchingEngineHelper.java
@@ -100,7 +100,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
     private String mDefaultCarrierName;
     private String mDefaultDmeHostname;
     public String mDmeHostname;
-    public String mCarrierName;
+    private String mCarrierName;
     public String mAppName;
     public String mAppVersion;
     public String mOrgName;
@@ -271,7 +271,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         onEdgeEventPreferenceChanged(prefs, prefKeyEnableEdgeEvents);
         onEdgeEventPreferenceChanged(prefs, prefKeyOverrideDefaultConfig);
 
-        Log.i(TAG, "mDmeHostname="+ mDmeHostname +" networkSwitchingAllowed="+mNetworkSwitchingAllowed+" mCarrierName="+mCarrierName);
+        Log.i(TAG, "mDmeHostname="+ mDmeHostname +" networkSwitchingAllowed="+mNetworkSwitchingAllowed+" mCarrierName="+getCarrierName());
 
         // Watch for any updated preferences:
         prefs.registerOnSharedPreferenceChangeListener(this);
@@ -454,7 +454,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         AppClient.RegisterClientRequest registerClientRequest;
         AppClient.RegisterClientReply registerReply;
         registerClientRequest = me.createDefaultRegisterClientRequest(mActivity, mOrgName)
-                .setAppName(mAppName).setAppVers(mAppVersion).setCarrierName(mCarrierName).build();
+                .setAppName(mAppName).setAppVers(mAppVersion).setCarrierName(getCarrierName()).build();
         registerReply = me.registerClient(registerClientRequest, mDmeHostname, mDmePort,10000);
         Log.i(TAG, "registerClientRequest="+registerClientRequest);
         Log.i(TAG, "registerClientRequest: "
@@ -698,7 +698,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
             return false;
         }
         AppClient.FindCloudletRequest findCloudletRequest;
-        findCloudletRequest = me.createDefaultFindCloudletRequest(mActivity, getLocationForMatching()).setCarrierName(mCarrierName).build();
+        findCloudletRequest = me.createDefaultFindCloudletRequest(mActivity, getLocationForMatching()).setCarrierName(getCarrierName()).build();
         mClosestCloudlet = me.findCloudlet(findCloudletRequest,
                 mDmeHostname, mDmePort,10000, mFindCloudletMode);
 
@@ -789,7 +789,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         }
 
         AppClient.AppInstListRequest appInstListRequest
-                = me.createDefaultAppInstListRequest(mActivity, getLocationForMatching()).setCarrierName(mCarrierName).setLimit(mAppInstancesLimit).build();
+                = me.createDefaultAppInstListRequest(mActivity, getLocationForMatching()).setCarrierName(getCarrierName()).setLimit(mAppInstancesLimit).build();
         if(appInstListRequest != null) {
             AppClient.AppInstListReply cloudletList = me.getAppInstList(appInstListRequest,
                     mDmeHostname, mDmePort, 10000);
@@ -819,7 +819,7 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         // Location Verification (Blocking, or use verifyLocationFuture):
         AppClient.VerifyLocationRequest verifyRequest =
                 me.createDefaultVerifyLocationRequest(mActivity, getLocationForMatching())
-                        .setCarrierName(mCarrierName).build();
+                        .setCarrierName(getCarrierName()).build();
         if (verifyRequest != null) {
             AppClient.VerifyLocationReply verifiedLocation =
                     me.verifyLocation(verifyRequest, mDmeHostname, mDmePort, 10000);
@@ -1218,6 +1218,14 @@ public class MatchingEngineHelper implements SharedPreferences.OnSharedPreferenc
         if (key.equals(prefKeyAutoMigration)) {
             boolean value = prefs.getBoolean(key, false);
             me.setAutoMigrateEdgeEventsConnection(value);
+        }
+    }
+
+    public String getCarrierName() {
+        if (me.isUseWifiOnly()) {
+            return "";
+        } else {
+            return mCarrierName;
         }
     }
 

--- a/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
+++ b/android/MobiledgeXSDKDemo/matchingenginehelper/src/main/java/com/mobiledgex/matchingenginehelper/SettingsActivity.java
@@ -200,6 +200,14 @@ public class SettingsActivity extends AppCompatActivity implements
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             prefs.registerOnSharedPreferenceChangeListener(this);
 
+            // Disable/Enable "Operator" items based on pref from another page. Can't use
+            // regular `android:dependency` to control this because that's already used
+            // for the "Use Default Operator" checkbox dependency.
+            boolean wifiOnly = prefs.getBoolean(getResources().getString(R.string.pref_use_wifi_only), false);
+            Log.i(TAG, "wifiOnly="+wifiOnly);
+            findPreference(prefKeyDefaultOperatorName).setEnabled(!wifiOnly);
+            findPreference(prefKeyOperatorName).setEnabled(!wifiOnly);
+
             // Initialize summary values for these keys.
             onSharedPreferenceChanged(prefs, prefKeyMeLocationVerification);
             onSharedPreferenceChanged(prefs, prefKeyDefaultOperatorName);
@@ -297,7 +305,12 @@ public class SettingsActivity extends AppCompatActivity implements
 
             if (key.equals(prefKeyOperatorName)) {
                 String summary = getResources().getString(R.string.pref_summary_operator_name);
-                pref.setSummary(summary + ": " + ((EditTextPreference)pref).getText());
+                summary += ": " + ((EditTextPreference)pref).getText();
+                boolean wifiOnly = prefs.getBoolean(getResources().getString(R.string.pref_use_wifi_only), false);
+                if (wifiOnly) {
+                    summary += ("\n(Disabled due to \"Use Wifi Only\" being turned on.)");
+                }
+                pref.setSummary(summary);
             }
 
             if (key.equals(prefKeyDefaultAppInfo)) {


### PR DESCRIPTION
- When wifi-only is turned on, editing of the Operator preferences is disabled.
- When wifi-only is turned on, always use "" (wildcard) value for setCarrierName() for any MatchingEngine call.